### PR TITLE
Fixed wrong slugify reference, cursor error, added MYSQL port

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ python mysql2sqlite.py -h
 ```
 usage: mysql2sqlite.py [-h] [-f SQLITE_FILE] [-u MYSQL_USER]
                        [-p MYSQL_PASSWORD] [-d MYSQL_DATABASE]
-                       [--mysql-host MYSQL_HOST] [-c CHUNK] [-l LOG_FILE] [-V]
+                       [--mysql-host MYSQL_HOST] [--mysql-port MYSQL_PORT]
+                       [-c CHUNK] [-l LOG_FILE] [-V]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -30,9 +31,11 @@ optional arguments:
   -p MYSQL_PASSWORD, --mysql-password MYSQL_PASSWORD
                         MySQL password
   -d MYSQL_DATABASE, --mysql-database MYSQL_DATABASE
-                        MySQL host
+                        MySQL database name
   --mysql-host MYSQL_HOST
-                        MySQL host
+                        MySQL host (default: localhost)
+  --mysql-port MYSQL_PORT
+                        MySQL port (default: 3306)
   -c CHUNK, --chunk CHUNK
                         Chunk reading/writing SQL records
   -l LOG_FILE, --log-file LOG_FILE

--- a/mysql2sqlite.py
+++ b/mysql2sqlite.py
@@ -272,13 +272,13 @@ if __name__ == "__main__":
         help="MySQL password",
     )
     parser.add_argument(
-        "-d", "--mysql-database", dest="mysql_database", default=None, help="MySQL host"
+        "-d", "--mysql-database", dest="mysql_database", default=None, help="MySQL database name"
     )
     parser.add_argument(
-        "--mysql-host", dest="mysql_host", default="localhost", help="MySQL host"
+        "--mysql-host", dest="mysql_host", default="localhost", help="MySQL host (default: localhost)"
     )
     parser.add_argument(
-        "--mysql-port", dest="mysql_port", default="3306", help="MySQL port"
+        "--mysql-port", dest="mysql_port", default="3306", help="MySQL port (default: 3306)"
     )
     parser.add_argument(
         "-c",

--- a/mysql2sqlite.py
+++ b/mysql2sqlite.py
@@ -43,9 +43,10 @@ class MySQL2SQLite:
             user=kwargs.get("mysql_user", None),
             password=kwargs.get("mysql_password", None),
             host=kwargs.get("mysql_host", "localhost"),
+			port=kwargs.get("mysql_port", "3306"),
         )
-        self._mysql_cur = self._mysql.cursor(raw=True)
-        self._mysql_cur_dict = self._mysql.cursor(dictionary=True)
+        self._mysql_cur = self._mysql.cursor(raw=True, buffered=True)
+        self._mysql_cur_dict = self._mysql.cursor(dictionary=True, buffered=True)
         try:
             self._mysql.database = self._mysql_database
         except mysql.connector.Error as err:
@@ -277,6 +278,9 @@ if __name__ == "__main__":
         "--mysql-host", dest="mysql_host", default="localhost", help="MySQL host"
     )
     parser.add_argument(
+        "--mysql-port", dest="mysql_port", default="3306", help="MySQL port"
+    )
+    parser.add_argument(
         "-c",
         "--chunk",
         dest="chunk",
@@ -306,6 +310,7 @@ if __name__ == "__main__":
             mysql_password=args.mysql_password,
             mysql_database=args.mysql_database,
             mysql_host=args.mysql_host,
+            mysql_port=args.mysql_port,
             chunk=args.chunk,
             vacuum=args.vacuum,
             log_file=args.log_file,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mysql-connector-python==8.0.15
 protobuf==3.6.1
 six==1.12.0
-slugify==0.0.1
+python-slugify==3.0.0
 tqdm==4.31.1


### PR DESCRIPTION
Thanks for making this 👍 It took me a short while to actually get it working due to some issues which I fixed in this commit.

The original requirements.txt pointed to `slugify` = https://github.com/zacharyvoase/slugify which is probably not the version that we should use, as it throws errors. Updated it to `python-slugify`, https://github.com/un33k/python-slugify.

I got an error `InternalError (Unread result found)` when using the code as-is, and this was fixed by setting the mysql connection to buffered (I did not heavily troubleshoot this, just applied the fix and it worked).

My server was not running on port 3306 (but on 3307 - running MariaDB 5 and MariaDB 10 in parallel), so added the option to specify the port.