### PR TITLE
Feature update -exclude to exclude tables

### DIFF
--- a/mysql_to_sqlite3/cli.py
+++ b/mysql_to_sqlite3/cli.py
@@ -41,6 +41,13 @@ from .sqlite_utils import CollatingSequences
     "Implies --without-foreign-keys which inhibits the transfer of foreign keys.",
 )
 @click.option(
+    "-e",
+    "--exclude",
+    type=list,
+    cls=OptionEatAll,
+    help="Exclude thes specific tables from Transfering (space separated table names).",
+)
+@click.option(
     "-L",
     "--limit-rows",
     type=int,
@@ -123,6 +130,7 @@ def cli(
     mysql_password,
     mysql_database,
     mysql_tables,
+    exclude,
     limit_rows,
     collation,
     prefix_indices,
@@ -147,6 +155,7 @@ def cli(
             mysql_password=mysql_password or prompt_mysql_password,
             mysql_database=mysql_database,
             mysql_tables=mysql_tables,
+            exclude=exclude,
             limit_rows=limit_rows,
             collation=collation,
             prefix_indices=prefix_indices,

--- a/mysql_to_sqlite3/transporter.py
+++ b/mysql_to_sqlite3/transporter.py
@@ -505,7 +505,7 @@ class MySQLtoSQLite:
                 WHERE TABLE_SCHEMA = SCHEMA()
                 {exclude_format}
             """.format(
-                exclude_format = ('AND ({phrase})').format(phrase=' OR '.join([f'TABLE_NAME LIKE "{x}"' for x in self._exclude]))
+                exclude_format = ('AND ({phrase})').format(phrase=' OR '.join(['TABLE_NAME LIKE "{x}"'.format(x=x) for x in self._exclude]))
                 )
             )
             filtered = '\n            AND TABLE_NAME NOT IN ({f})'.format(
@@ -517,7 +517,7 @@ class MySQLtoSQLite:
         # transfer only specific tables
         inc = '\n            AND TABLE_NAME IN ({placeholders})'.format(
                     placeholders=', '.join(
-                        f'"{w}"' for w in self._mysql_tables
+                        '"{w}"'.format(w=w) for w in self._mysql_tables
                     )
                 ) if len(self._mysql_tables) > 0 else ''
 

--- a/mysql_to_sqlite3/transporter.py
+++ b/mysql_to_sqlite3/transporter.py
@@ -510,7 +510,7 @@ class MySQLtoSQLite:
             )
             filtered = '\n            AND TABLE_NAME NOT IN ({f})'.format(
                             f=', '.join(
-                            [f'"{row[0]}"' for row in self._mysql_cur_prepared.fetchall()]
+                            ['"{r}"'.format(r=row[0]) for row in self._mysql_cur_prepared.fetchall()]
                             )
                         )
 
@@ -523,11 +523,14 @@ class MySQLtoSQLite:
 
         # run resulting query
         self._mysql_cur_prepared.execute(
-            f"""
+            """
             SELECT TABLE_NAME
             FROM information_schema.TABLES
             WHERE TABLE_SCHEMA = SCHEMA(){inc}{filtered}
-            """
+            """.format(
+                inc=inc,
+                filtered=filtered
+                )
         )
         tables = (row[0] for row in self._mysql_cur_prepared.fetchall())
 


### PR DESCRIPTION
Merged queries and added option to filter out tables using exclude keyword.

May need to be fixed to allow for correct use of -exclude tag with --without-foreign-keys
May be worth adding an else statement to remove 'exclude' filter if 'mysql_tables' filter is set.
Code formatting may be needed.


Merged --mysql-tables and --exclude (or none) into single query.
