### PR TITLE
:fire: drop support for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,12 +33,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - toxenv: "python3.7"
-            db: "mariadb:5.5"
-            legacy_db: 1
-            experimental: false
-            py: "3.7"
-
           - toxenv: "python3.8"
             db: "mariadb:5.5"
             legacy_db: 1
@@ -62,12 +56,6 @@ jobs:
             legacy_db: 1
             experimental: false
             py: "3.11"
-
-          - toxenv: "python3.7"
-            db: "mariadb:10.0"
-            legacy_db: 1
-            experimental: false
-            py: "3.7"
 
           - toxenv: "python3.8"
             db: "mariadb:10.0"
@@ -93,12 +81,6 @@ jobs:
             experimental: false
             py: "3.11"
 
-          - toxenv: "python3.7"
-            db: "mariadb:10.1"
-            legacy_db: 1
-            experimental: false
-            py: "3.7"
-
           - toxenv: "python3.8"
             db: "mariadb:10.1"
             legacy_db: 1
@@ -122,12 +104,6 @@ jobs:
             legacy_db: 1
             experimental: false
             py: "3.11"
-
-          - toxenv: "python3.7"
-            db: "mariadb:10.2"
-            legacy_db: 0
-            experimental: false
-            py: "3.7"
 
           - toxenv: "python3.8"
             db: "mariadb:10.2"
@@ -153,12 +129,6 @@ jobs:
             experimental: false
             py: "3.11"
 
-          - toxenv: "python3.7"
-            db: "mariadb:10.3"
-            legacy_db: 0
-            experimental: false
-            py: "3.7"
-
           - toxenv: "python3.8"
             db: "mariadb:10.3"
             legacy_db: 0
@@ -182,12 +152,6 @@ jobs:
             legacy_db: 0
             experimental: false
             py: "3.11"
-
-          - toxenv: "python3.7"
-            db: "mariadb:10.4"
-            legacy_db: 0
-            experimental: false
-            py: "3.7"
 
           - toxenv: "python3.8"
             db: "mariadb:10.4"
@@ -213,12 +177,6 @@ jobs:
             experimental: false
             py: "3.11"
 
-          - toxenv: "python3.7"
-            db: "mariadb:10.5"
-            legacy_db: 0
-            experimental: false
-            py: "3.7"
-
           - toxenv: "python3.8"
             db: "mariadb:10.5"
             legacy_db: 0
@@ -242,12 +200,6 @@ jobs:
             legacy_db: 0
             experimental: false
             py: "3.11"
-
-          - toxenv: "python3.7"
-            db: "mariadb:10.6"
-            legacy_db: 0
-            experimental: false
-            py: "3.7"
 
           - toxenv: "python3.8"
             db: "mariadb:10.6"
@@ -273,12 +225,6 @@ jobs:
             experimental: false
             py: "3.11"
 
-          - toxenv: "python3.7"
-            db: "mariadb:10.11"
-            legacy_db: 0
-            experimental: false
-            py: "3.7"
-
           - toxenv: "python3.8"
             db: "mariadb:10.11"
             legacy_db: 0
@@ -302,12 +248,6 @@ jobs:
             legacy_db: 0
             experimental: false
             py: "3.11"
-
-          - toxenv: "python3.7"
-            db: "mysql:5.5"
-            legacy_db: 1
-            experimental: false
-            py: "3.7"
 
           - toxenv: "python3.8"
             db: "mysql:5.5"
@@ -333,12 +273,6 @@ jobs:
             experimental: false
             py: "3.11"
 
-          - toxenv: "python3.7"
-            db: "mysql:5.6"
-            legacy_db: 1
-            experimental: false
-            py: "3.7"
-
           - toxenv: "python3.8"
             db: "mysql:5.6"
             legacy_db: 1
@@ -363,12 +297,6 @@ jobs:
             experimental: false
             py: "3.11"
 
-          - toxenv: "python3.7"
-            db: "mysql:5.7"
-            legacy_db: 0
-            experimental: false
-            py: "3.7"
-
           - toxenv: "python3.8"
             db: "mysql:5.7"
             legacy_db: 0
@@ -392,12 +320,6 @@ jobs:
             legacy_db: 0
             experimental: false
             py: "3.11"
-
-          - toxenv: "python3.7"
-            db: "mysql:8.0"
-            legacy_db: 0
-            experimental: false
-            py: "3.7"
 
           - toxenv: "python3.8"
             db: "mysql:8.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.0
+
+* [CHORE] drop support for Python 3.7
+
 # 2.0.3
 
 * [FIX] import MySQLConnectionAbstract instead of concrete implementations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ interactions related to the project.
 
 Ensuring backward compatibility is an imperative requirement.
 
-Currently, the tool supports Python versions 3.7, 3.8, 3.9, 3.10 and 3.11.
+Currently, the tool supports Python versions 3.8, 3.9, 3.10 and 3.11.
 
 ## MySQL version support
 
@@ -31,20 +31,6 @@ utmost importance to ensure thorough testing. Please remember to write tests for
 In order to run the test suite run these commands using a Docker MySQL image.
 
 **Requires a running Docker instance!**
-
-- using Python 2.7
-
-```bash
-git clone https://github.com/techouse/mysql-to-sqlite3
-cd mysql-to-sqlite3
-virtualenv -p $(which python2) env
-source env/bin/activate
-pip install -e .
-pip install -r requirements_dev.txt
-tox
-```
-
-- using Python 3.5+
 
 ```bash
 git clone https://github.com/techouse/mysql-to-sqlite3

--- a/mysql_to_sqlite3/__init__.py
+++ b/mysql_to_sqlite3/__init__.py
@@ -1,4 +1,4 @@
 """Utility to transfer data from MySQL to SQLite 3."""
-__version__ = "2.0.3"
+__version__ = "2.1.0"
 
 from .transporter import MySQLtoSQLite

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "mysql-to-sqlite3"
 description = "A simple Python tool to transfer data from MySQL to SQLite 3"
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Klemen Tusar", email = "techouse@gmail.com" },
 ]
@@ -30,7 +30,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -69,7 +68,7 @@ mysql2sqlite = "mysql_to_sqlite3.cli:cli"
 
 [tool.black]
 line-length = 120
-target-version = ["py37", "py38", "py39", "py310", "py311"]
+target-version = ["py38", "py39", "py310", "py311"]
 include = '\.pyi?$'
 exclude = '''
 (
@@ -110,7 +109,7 @@ markers = [
 ]
 
 [tool.mypy]
-python_version = "3.7"
+python_version = "3.8"
 exclude = [
     "tests",
     "build",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 isolated_build = true
 envlist =
-    python3.7,
     python3.8,
     python3.9,
     python3.10,
@@ -13,7 +12,6 @@ skip_missing_interpreters = true
 
 [gh-actions]
 python =
-    3.7: python3.7
     3.8: python3.8
     3.9: python3.9
     3.10: python3.10


### PR DESCRIPTION
Python 3.7 reached EOL on 27/06/2023. With most packages that this package relies on dropping support for it, I will follow suit.