### PR TITLE
:bookmark: release v2.1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,12 @@ jobs:
             experimental: false
             py: "3.11"
 
+          - toxenv: "python3.12"
+            db: "mariadb:5.5"
+            legacy_db: 1
+            experimental: false
+            py: "3.12"
+
           - toxenv: "python3.8"
             db: "mariadb:10.0"
             legacy_db: 1
@@ -80,6 +86,12 @@ jobs:
             legacy_db: 1
             experimental: false
             py: "3.11"
+
+          - toxenv: "python3.12"
+            db: "mariadb:10.0"
+            legacy_db: 1
+            experimental: false
+            py: "3.12"
 
           - toxenv: "python3.8"
             db: "mariadb:10.1"
@@ -105,6 +117,12 @@ jobs:
             experimental: false
             py: "3.11"
 
+          - toxenv: "python3.12"
+            db: "mariadb:10.1"
+            legacy_db: 1
+            experimental: false
+            py: "3.12"
+
           - toxenv: "python3.8"
             db: "mariadb:10.2"
             legacy_db: 0
@@ -128,6 +146,12 @@ jobs:
             legacy_db: 0
             experimental: false
             py: "3.11"
+
+          - toxenv: "python3.12"
+            db: "mariadb:10.2"
+            legacy_db: 0
+            experimental: false
+            py: "3.12"
 
           - toxenv: "python3.8"
             db: "mariadb:10.3"
@@ -153,6 +177,12 @@ jobs:
             experimental: false
             py: "3.11"
 
+          - toxenv: "python3.12"
+            db: "mariadb:10.3"
+            legacy_db: 0
+            experimental: false
+            py: "3.12"
+
           - toxenv: "python3.8"
             db: "mariadb:10.4"
             legacy_db: 0
@@ -176,6 +206,12 @@ jobs:
             legacy_db: 0
             experimental: false
             py: "3.11"
+
+          - toxenv: "python3.12"
+            db: "mariadb:10.4"
+            legacy_db: 0
+            experimental: false
+            py: "3.12"
 
           - toxenv: "python3.8"
             db: "mariadb:10.5"
@@ -201,6 +237,12 @@ jobs:
             experimental: false
             py: "3.11"
 
+          - toxenv: "python3.12"
+            db: "mariadb:10.5"
+            legacy_db: 0
+            experimental: false
+            py: "3.12"
+
           - toxenv: "python3.8"
             db: "mariadb:10.6"
             legacy_db: 0
@@ -224,6 +266,12 @@ jobs:
             legacy_db: 0
             experimental: false
             py: "3.11"
+
+          - toxenv: "python3.12"
+            db: "mariadb:10.6"
+            legacy_db: 0
+            experimental: false
+            py: "3.12"
 
           - toxenv: "python3.8"
             db: "mariadb:10.11"
@@ -249,6 +297,12 @@ jobs:
             experimental: false
             py: "3.11"
 
+          - toxenv: "python3.12"
+            db: "mariadb:10.11"
+            legacy_db: 0
+            experimental: false
+            py: "3.12"
+
           - toxenv: "python3.8"
             db: "mysql:5.5"
             legacy_db: 1
@@ -272,6 +326,12 @@ jobs:
             legacy_db: 1
             experimental: false
             py: "3.11"
+
+          - toxenv: "python3.12"
+            db: "mysql:5.5"
+            legacy_db: 1
+            experimental: false
+            py: "3.12"
 
           - toxenv: "python3.8"
             db: "mysql:5.6"
@@ -297,6 +357,12 @@ jobs:
             experimental: false
             py: "3.11"
 
+          - toxenv: "python3.12"
+            db: "mysql:5.6"
+            legacy_db: 1
+            experimental: false
+            py: "3.12"
+
           - toxenv: "python3.8"
             db: "mysql:5.7"
             legacy_db: 0
@@ -321,6 +387,12 @@ jobs:
             experimental: false
             py: "3.11"
 
+          - toxenv: "python3.12"
+            db: "mysql:5.7"
+            legacy_db: 0
+            experimental: false
+            py: "3.12"
+
           - toxenv: "python3.8"
             db: "mysql:8.0"
             legacy_db: 0
@@ -344,6 +416,12 @@ jobs:
             legacy_db: 0
             experimental: false
             py: "3.11"
+
+          - toxenv: "python3.12"
+            db: "mysql:8.0"
+            legacy_db: 0
+            experimental: false
+            py: "3.12"
     continue-on-error: ${{ matrix.experimental }}
     services:
       mysql:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.1.1
+
+* [CHORE] add support for Python 3.12
+* [CHORE] bump minimum version of MySQL Connector/Python to 8.2.0
+
 # 2.1.0
 
 * [CHORE] drop support for Python 3.7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ interactions related to the project.
 
 Ensuring backward compatibility is an imperative requirement.
 
-Currently, the tool supports Python versions 3.8, 3.9, 3.10 and 3.11.
+Currently, the tool supports Python versions 3.8, 3.9, 3.10, 3.11, and 3.12.
 
 ## MySQL version support
 

--- a/mysql_to_sqlite3/__init__.py
+++ b/mysql_to_sqlite3/__init__.py
@@ -1,4 +1,4 @@
 """Utility to transfer data from MySQL to SQLite 3."""
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 from .transporter import MySQLtoSQLite

--- a/mysql_to_sqlite3/debug_info.py
+++ b/mysql_to_sqlite3/debug_info.py
@@ -7,7 +7,7 @@ import platform
 import sqlite3
 import sys
 import typing as t
-from distutils.spawn import find_executable  # pylint: disable=W0402
+from shutil import which
 from subprocess import check_output
 
 import click
@@ -56,7 +56,7 @@ def _implementation() -> str:
 
 
 def _mysql_version() -> str:
-    if find_executable("mysql"):
+    if which("mysql") is not None:
         try:
             mysql_version: t.Union[str, bytes] = check_output(["mysql", "-V"])
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,13 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Database",
 ]
 dependencies = [
     "Click>=8.1.3",
-    "mysql-connector-python>=8.0.33",
+    "mysql-connector-python>=8.2.0",
     "pytimeparse2",
     "python-slugify>=7.0.0",
     "simplejson>=3.19.0",
@@ -68,7 +69,7 @@ mysql2sqlite = "mysql_to_sqlite3.cli:cli"
 
 [tool.black]
 line-length = 120
-target-version = ["py38", "py39", "py310", "py311"]
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 include = '\.pyi?$'
 exclude = '''
 (

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,7 @@ Click>=8.1.3
 docker>=6.1.3
 factory-boy
 Faker>=18.10.0
-mysql-connector-python>=8.0.33
+mysql-connector-python>=8.2.0
 mysqlclient>=2.1.1
 pytest>=7.3.1
 pytest-cov
@@ -19,7 +19,7 @@ types-sqlalchemy-utils
 tox
 tqdm>=4.65.0
 types-tqdm
-packaging>=23.1
+packaging
 tabulate
 types-tabulate
 typing_extensions

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     python3.9,
     python3.10,
     python3.11,
+    python3.12,
     black,
     flake8,
     linters
@@ -16,6 +17,7 @@ python =
     3.9: python3.9
     3.10: python3.10
     3.11: python3.11
+    3.12: python3.12
 
 [testenv]
 passenv =


### PR DESCRIPTION
# 2.1.1

* [CHORE] add support for Python 3.12
* [CHORE] bump minimum version of MySQL Connector/Python to 8.2.0