### PR TITLE
Support for MySQL SSL options (`--mysql-ssl-cert`, `--mysql-ssl-key`, `--mysql-ssl-ca`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Options:
   -W, --without-data              Do not transfer table data, DDL only.
   -h, --mysql-host TEXT           MySQL host. Defaults to localhost.
   -P, --mysql-port INTEGER        MySQL port. Defaults to 3306.
+  --mysql-ssl-cert PATH           Path to SSL certificate file.
+  --mysql-ssl-key PATH            Path to SSL key file.
+  --mysql-ssl-ca PATH             Path to SSL CA certificate file.
   -S, --skip-ssl                  Disable MySQL connection encryption.
   -c, --chunk INTEGER             Chunk reading/writing SQL records
   -l, --log-file PATH             Log file

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -43,6 +43,9 @@ Connection Options
 
 - ``-h, --mysql-host TEXT``: MySQL host. Defaults to localhost.
 - ``-P, --mysql-port INTEGER``: MySQL port. Defaults to 3306.
+- ``--mysql-ssl-cert PATH``: Path to SSL certificate file.
+- ``--mysql-ssl-key PATH``: Path to SSL key file.
+- ``--mysql-ssl-ca PATH``: Path to SSL CA certificate file.
 - ``-S, --skip-ssl``: Disable MySQL connection encryption.
 
 Other Options

--- a/src/mysql_to_sqlite3/cli.py
+++ b/src/mysql_to_sqlite3/cli.py
@@ -100,6 +100,9 @@ _copyright_header: str = f"mysql2sqlite version {package_version} Copyright (c) 
 )
 @click.option("-h", "--mysql-host", default="localhost", help="MySQL host. Defaults to localhost.")
 @click.option("-P", "--mysql-port", type=int, default=3306, help="MySQL port. Defaults to 3306.")
+@click.option("--mysql-ssl-cert", type=click.Path(), help="Path to SSL certificate file.")
+@click.option("--mysql-ssl-key", type=click.Path(), help="Path to SSL key file.")
+@click.option("--mysql-ssl-ca", type=click.Path(), help="Path to SSL CA certificate file.")
 @click.option("-S", "--skip-ssl", is_flag=True, help="Disable MySQL connection encryption.")
 @click.option(
     "-c",
@@ -142,6 +145,9 @@ def cli(
     without_data: bool,
     mysql_host: str,
     mysql_port: int,
+    mysql_ssl_cert: t.Optional[str],
+    mysql_ssl_key: t.Optional[str],
+    mysql_ssl_ca: t.Optional[str],
     skip_ssl: bool,
     chunk: int,
     log_file: t.Union[str, "os.PathLike[t.Any]"],
@@ -171,6 +177,9 @@ def cli(
             without_data=without_data,
             mysql_host=mysql_host,
             mysql_port=mysql_port,
+            mysql_ssl_cert=mysql_ssl_cert,
+            mysql_ssl_key=mysql_ssl_key,
+            mysql_ssl_ca=mysql_ssl_ca,
             mysql_ssl_disabled=skip_ssl,
             chunk=chunk,
             json_as_text=json_as_text,

--- a/src/mysql_to_sqlite3/transporter.py
+++ b/src/mysql_to_sqlite3/transporter.py
@@ -88,6 +88,12 @@ class MySQLtoSQLite(MySQLtoSQLiteAttributes):
 
         self._without_data = kwargs.get("without_data") or False
 
+        self._mysql_ssl_ca = kwargs.get("mysql_ssl_ca") or None
+
+        self._mysql_ssl_cert = kwargs.get("mysql_ssl_cert") or None
+
+        self._mysql_ssl_key = kwargs.get("mysql_ssl_key") or None
+
         self._mysql_ssl_disabled = kwargs.get("mysql_ssl_disabled") or False
 
         self._current_chunk_number = 0
@@ -123,6 +129,9 @@ class MySQLtoSQLite(MySQLtoSQLiteAttributes):
                 password=self._mysql_password,
                 host=self._mysql_host,
                 port=self._mysql_port,
+                ssl_ca=self._mysql_ssl_ca,
+                ssl_cert=self._mysql_ssl_cert,
+                ssl_key=self._mysql_ssl_key,
                 ssl_disabled=self._mysql_ssl_disabled,
             )
             if isinstance(_mysql_connection, MySQLConnectionAbstract):


### PR DESCRIPTION
# Pull Request: Add MySQL SSL Options

## Description

This pull request adds support for MySQL SSL options (`--mysql-ssl-cert`, `--mysql-ssl-key`, `--mysql-ssl-ca`), that allow users to specify the paths to SSL certificate, key, and CA certificate files when connecting to MySQL databases that require secure transport (`--require_secure_transport=ON`).
This enhancement aims to address the issue where connections using insecure transport are prohibited due to MySQL server settings, e.g. when this error message appears:

> ERROR    3159 (HY000): Connections using insecure transport are prohibited while --require_secure_transport=ON.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

These changes have been tested locally by connecting to MySQL databases with `--require_secure_transport=ON` using the newly introduced SSL options.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
