### PR TITLE
:sparkles: add `--without-tables` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ mysql2sqlite --help
 ```
 Usage: mysql2sqlite [OPTIONS]
 
-  Transfer MySQL to SQLite using the provided CLI options.
+  mysql2sqlite version 2.1.12 Copyright (c) 2019-2024 Klemen Tusar
 
 Options:
   -f, --sqlite-file PATH          SQLite3 database file  [required]
@@ -44,27 +44,23 @@ Options:
                                   foreign-keys which inhibits the transfer of
                                   foreign keys. Can not be used together with
                                   --exclude-mysql-tables.
-
   -e, --exclude-mysql-tables TUPLE
                                   Transfer all tables except these specific
                                   tables (space separated table names).
                                   Implies --without-foreign-keys which
                                   inhibits the transfer of foreign keys. Can
                                   not be used together with --mysql-tables.
-
   -L, --limit-rows INTEGER        Transfer only a limited number of rows from
                                   each table.
-
   -C, --collation [BINARY|NOCASE|RTRIM]
                                   Create datatypes of TEXT affinity using a
                                   specified collation sequence.  [default:
                                   BINARY]
-
   -K, --prefix-indices            Prefix indices with their corresponding
                                   tables. This ensures that their names remain
                                   unique across the SQLite database.
-
   -X, --without-foreign-keys      Do not transfer foreign keys.
+  -Z, --without-tables            Do not transfer tables, data only.
   -W, --without-data              Do not transfer table data, DDL only.
   -h, --mysql-host TEXT           MySQL host. Defaults to localhost.
   -P, --mysql-port INTEGER        MySQL port. Defaults to 3306.
@@ -75,13 +71,11 @@ Options:
   -V, --vacuum                    Use the VACUUM command to rebuild the SQLite
                                   database file, repacking it into a minimal
                                   amount of disk space
-
   --use-buffered-cursors          Use MySQLCursorBuffered for reading the
                                   MySQL database. This can be useful in
                                   situations where multiple queries, with
                                   small result sets, need to be combined or
                                   computed with each other.
-
   -q, --quiet                     Quiet. Display only errors.
   --debug                         Debug mode. Will throw exceptions.
   --version                       Show the version and exit.

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -36,6 +36,7 @@ Transfer Options
 - ``-C, --collation [BINARY|NOCASE|RTRIM]``: Create datatypes of TEXT affinity using a specified collation sequence. The default is BINARY.
 - ``-K, --prefix-indices``: Prefix indices with their corresponding tables. This ensures that their names remain unique across the SQLite database.
 - ``-X, --without-foreign-keys``: Do not transfer foreign keys.
+- ``-Z, --without-tables``: Do not transfer tables, data only.
 - ``-W, --without-data``: Do not transfer table data, DDL only.
 
 Connection Options

--- a/src/mysql_to_sqlite3/cli.py
+++ b/src/mysql_to_sqlite3/cli.py
@@ -93,6 +93,12 @@ _copyright_header: str = f"mysql2sqlite version {package_version} Copyright (c) 
 )
 @click.option("-X", "--without-foreign-keys", is_flag=True, help="Do not transfer foreign keys.")
 @click.option(
+    "-Z",
+    "--without-tables",
+    is_flag=True,
+    help="Do not transfer tables, data only.",
+)
+@click.option(
     "-W",
     "--without-data",
     is_flag=True,
@@ -139,6 +145,7 @@ def cli(
     collation: t.Optional[str],
     prefix_indices: bool,
     without_foreign_keys: bool,
+    without_tables: bool,
     without_data: bool,
     mysql_host: str,
     mysql_port: int,
@@ -154,6 +161,12 @@ def cli(
     """Transfer MySQL to SQLite using the provided CLI options."""
     click.echo(_copyright_header)
     try:
+        # check if both mysql_skip_create_table and mysql_skip_transfer_data are True
+        if without_tables and without_data:
+            raise click.ClickException(
+                "Error: Both -Z/--without-tables and -W/--without-data are set. There is nothing to do. Exiting..."
+            )
+
         if mysql_tables and exclude_mysql_tables:
             raise click.UsageError("Illegal usage: --mysql-tables and --exclude-mysql-tables are mutually exclusive!")
 
@@ -168,6 +181,7 @@ def cli(
             collation=collation,
             prefix_indices=prefix_indices,
             without_foreign_keys=without_foreign_keys or (mysql_tables is not None and len(mysql_tables) > 0),
+            without_tables=without_tables,
             without_data=without_data,
             mysql_host=mysql_host,
             mysql_port=mysql_port,

--- a/src/mysql_to_sqlite3/types.py
+++ b/src/mysql_to_sqlite3/types.py
@@ -31,6 +31,7 @@ class MySQLtoSQLiteParams(tx.TypedDict):
     quiet: t.Optional[bool]
     sqlite_file: t.Union[str, "os.PathLike[t.Any]"]
     vacuum: t.Optional[bool]
+    without_tables: t.Optional[bool]
     without_data: t.Optional[bool]
     without_foreign_keys: t.Optional[bool]
 
@@ -62,6 +63,7 @@ class MySQLtoSQLiteAttributes:
     _sqlite: Connection
     _sqlite_cur: Cursor
     _sqlite_file: t.Union[str, "os.PathLike[t.Any]"]
+    _without_tables: bool
     _sqlite_json1_extension_enabled: bool
     _vacuum: bool
     _without_data: bool

--- a/tests/func/mysql_to_sqlite3_test.py
+++ b/tests/func/mysql_to_sqlite3_test.py
@@ -199,6 +199,29 @@ class TestMySQLtoSQLite:
             assert any("MySQL Database does not exist!" in message for message in caplog.messages)
         assert "Unknown database" in str(excinfo.value)
 
+    @pytest.mark.init
+    def test_without_tables_and_without_data(
+        self,
+        sqlite_database: "os.PathLike[t.Any]",
+        mysql_database: Database,
+        mysql_credentials: MySQLCredentials,
+        caplog: LogCaptureFixture,
+        tmpdir: LocalPath,
+        faker: Faker,
+    ) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            MySQLtoSQLite(  # type: ignore[call-arg]
+                sqlite_file=sqlite_database,
+                mysql_user=mysql_credentials.user,
+                mysql_password=mysql_credentials.password,
+                mysql_database=mysql_credentials.database,
+                mysql_host=mysql_credentials.host,
+                mysql_port=mysql_credentials.port,
+                without_tables=True,
+                without_data=True,
+            )
+        assert "Unable to continue without transferring data or creating tables!" in str(excinfo.value)
+
     @pytest.mark.xfail
     @pytest.mark.init
     @pytest.mark.parametrize(

--- a/tests/func/test_cli.py
+++ b/tests/func/test_cli.py
@@ -219,6 +219,81 @@ class TestMySQLtoSQLite:
             }
         )
 
+    def test_without_data(
+        self,
+        cli_runner: CliRunner,
+        sqlite_database: "os.PathLike[t.Any]",
+        mysql_database: Database,
+        mysql_credentials: MySQLCredentials,
+    ) -> None:
+        result: Result = cli_runner.invoke(
+            mysql2sqlite,
+            [
+                "-f",
+                str(sqlite_database),
+                "-d",
+                mysql_credentials.database,
+                "-u",
+                mysql_credentials.user,
+                "--mysql-password",
+                mysql_credentials.password,
+                "-h",
+                mysql_credentials.host,
+                "-P",
+                str(mysql_credentials.port),
+                "-W",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_without_tables(
+        self,
+        cli_runner: CliRunner,
+        sqlite_database: "os.PathLike[t.Any]",
+        mysql_database: Database,
+        mysql_credentials: MySQLCredentials,
+    ) -> None:
+        # First we need to create the tables in the SQLite database
+        result1: Result = cli_runner.invoke(
+            mysql2sqlite,
+            [
+                "-f",
+                str(sqlite_database),
+                "-d",
+                mysql_credentials.database,
+                "-u",
+                mysql_credentials.user,
+                "--mysql-password",
+                mysql_credentials.password,
+                "-h",
+                mysql_credentials.host,
+                "-P",
+                str(mysql_credentials.port),
+                "-W",
+            ],
+        )
+        assert result1.exit_code == 0
+
+        result2: Result = cli_runner.invoke(
+            mysql2sqlite,
+            [
+                "-f",
+                str(sqlite_database),
+                "-d",
+                mysql_credentials.database,
+                "-u",
+                mysql_credentials.user,
+                "--mysql-password",
+                mysql_credentials.password,
+                "-h",
+                mysql_credentials.host,
+                "-P",
+                str(mysql_credentials.port),
+                "-Z",
+            ],
+        )
+        assert result2.exit_code == 0
+
     @pytest.mark.parametrize(
         "chunk, vacuum, use_buffered_cursors, quiet",
         [


### PR DESCRIPTION
## Description

This PR adds the option `--without-tables` which enables a user to skip table creation and transfer only data.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

CLI and function tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules