### PR TITLE
:sparkles: use dateutil.parse to parse SQLite dates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ dependencies = [
     "Click>=8.1.3",
     "mysql-connector-python==8.4.0",
     "pytimeparse2",
+    "python-dateutil>=2.9.0.post0",
+    "types_python_dateutil",
     "python-slugify>=7.0.0",
     "simplejson>=3.19.0",
     "tqdm>=4.65.0",

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,6 +9,8 @@ pytest-cov
 pytest-mock
 pytest-timeout
 pytimeparse2
+python-dateutil>=2.9.0.post0
+types_python_dateutil
 python-slugify>=7.0.0
 types-python-slugify
 simplejson>=3.19.1

--- a/src/mysql_to_sqlite3/sqlite_utils.py
+++ b/src/mysql_to_sqlite3/sqlite_utils.py
@@ -5,6 +5,7 @@ import typing as t
 from datetime import date, timedelta
 from decimal import Decimal
 
+from dateutil.parser import parse as dateutil_parse
 from pytimeparse2 import parse
 
 
@@ -46,10 +47,10 @@ class CollatingSequences:
     RTRIM: str = "RTRIM"
 
 
-def convert_date(value: t.Any) -> date:
+def convert_date(value: t.Union[str, bytes]) -> date:
     """Handle SQLite date conversion."""
     try:
-        return date.fromisoformat(value.decode())
+        return dateutil_parse(value.decode() if isinstance(value, bytes) else value).date()
     except ValueError as err:
         raise ValueError(f"DATE field contains {err}")  # pylint: disable=W0707
 

--- a/src/mysql_to_sqlite3/sqlite_utils.py
+++ b/src/mysql_to_sqlite3/sqlite_utils.py
@@ -5,7 +5,8 @@ import typing as t
 from datetime import date, timedelta
 from decimal import Decimal
 
-from dateutil.parser import parse as dateutil_parse, ParserError
+from dateutil.parser import ParserError
+from dateutil.parser import parse as dateutil_parse
 from pytimeparse2 import parse
 
 

--- a/src/mysql_to_sqlite3/sqlite_utils.py
+++ b/src/mysql_to_sqlite3/sqlite_utils.py
@@ -5,7 +5,7 @@ import typing as t
 from datetime import date, timedelta
 from decimal import Decimal
 
-from dateutil.parser import parse as dateutil_parse
+from dateutil.parser import parse as dateutil_parse, ParserError
 from pytimeparse2 import parse
 
 
@@ -51,7 +51,7 @@ def convert_date(value: t.Union[str, bytes]) -> date:
     """Handle SQLite date conversion."""
     try:
         return dateutil_parse(value.decode() if isinstance(value, bytes) else value).date()
-    except ValueError as err:
+    except ParserError as err:
         raise ValueError(f"DATE field contains {err}")  # pylint: disable=W0707
 
 


### PR DESCRIPTION
# Pull Request Template

## Description

Use [dateutil](https://pypi.org/project/python-dateutil/) to parse SQLite dates instead of `datetime.date.fromisoformat`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Test suite passes

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules