### PR TITLE
:sparkles: add support for deferred foreign keys via -D/--defer-foreign-keys

### DIFF
--- a/src/mysql_to_sqlite3/cli.py
+++ b/src/mysql_to_sqlite3/cli.py
@@ -93,6 +93,9 @@ _copyright_header: str = f"mysql2sqlite version {package_version} Copyright (c) 
     help="Prefix indices with their corresponding tables. "
     "This ensures that their names remain unique across the SQLite database.",
 )
+@click.option(
+    "-D", "--defer-foreign-keys", is_flag=True, help="Defer foreign key constraints until the end of the transfer."
+)
 @click.option("-X", "--without-foreign-keys", is_flag=True, help="Do not transfer foreign keys.")
 @click.option(
     "-Z",
@@ -164,6 +167,7 @@ def cli(
     limit_rows: int,
     collation: t.Optional[str],
     prefix_indices: bool,
+    defer_foreign_keys: bool,
     without_foreign_keys: bool,
     without_tables: bool,
     without_data: bool,
@@ -212,6 +216,11 @@ def cli(
             limit_rows=limit_rows,
             collation=collation,
             prefix_indices=prefix_indices,
+            defer_foreign_keys=(
+                defer_foreign_keys
+                if not without_foreign_keys and not (mysql_tables is not None and len(mysql_tables) > 0)
+                else False
+            ),
             without_foreign_keys=without_foreign_keys or (mysql_tables is not None and len(mysql_tables) > 0),
             without_tables=without_tables,
             without_data=without_data,

--- a/src/mysql_to_sqlite3/transporter.py
+++ b/src/mysql_to_sqlite3/transporter.py
@@ -97,9 +97,9 @@ class MySQLtoSQLite(MySQLtoSQLiteAttributes):
 
         if not self._without_foreign_keys and not bool(self._mysql_tables) and not bool(self._exclude_mysql_tables):
             self._defer_foreign_keys = bool(kwargs.get("defer_foreign_keys", False))
-            if self._defer_foreign_keys and sqlite3.sqlite_version_info < (3, 6, 19):
+            if self._defer_foreign_keys and sqlite3.sqlite_version < "3.6.19":
                 self._logger.warning(
-                    "SQLite %s lacks DEFERRABLE support – ignoring --defer-fks.", sqlite3.sqlite_version
+                    "SQLite %s lacks DEFERRABLE support. Ignoring -D/--defer-foreign-keys.", sqlite3.sqlite_version
                 )
                 self._defer_foreign_keys = False
         else:

--- a/src/mysql_to_sqlite3/types.py
+++ b/src/mysql_to_sqlite3/types.py
@@ -35,6 +35,7 @@ class MySQLtoSQLiteParams(tx.TypedDict):
     vacuum: t.Optional[bool]
     without_tables: t.Optional[bool]
     without_data: t.Optional[bool]
+    defer_foreign_keys: t.Optional[bool]
     without_foreign_keys: t.Optional[bool]
 
 
@@ -71,4 +72,5 @@ class MySQLtoSQLiteAttributes:
     _sqlite_json1_extension_enabled: bool
     _vacuum: bool
     _without_data: bool
+    _defer_foreign_keys: bool
     _without_foreign_keys: bool

--- a/tests/unit/test_transporter.py
+++ b/tests/unit/test_transporter.py
@@ -150,7 +150,7 @@ class TestMySQLtoSQLiteTransporter:
             assert "Test exception" in str(excinfo.value)
 
             # Verify that foreign keys are re-enabled in the finally block
-            mock_sqlite_cursor.execute.assert_called_with("PRAGMA foreign_keys=ON")
+            mock_sqlite_cursor.execute.assert_called_with("PRAGMA foreign_key_check")
 
     def test_constructor_missing_mysql_database(self) -> None:
         """Test constructor raises ValueError if mysql_database is missing."""

--- a/tests/unit/test_transporter.py
+++ b/tests/unit/test_transporter.py
@@ -225,3 +225,23 @@ class TestMySQLtoSQLiteTransporter:
         """Test _translate_default_from_mysql_to_sqlite with bytes default."""
         result = MySQLtoSQLite._translate_default_from_mysql_to_sqlite(b"abc", column_type="BLOB")
         assert result.startswith("DEFAULT x'")
+
+    def test_translate_default_from_mysql_to_sqlite_curtime(self) -> None:
+        """Test _translate_default_from_mysql_to_sqlite with curtime()."""
+        assert MySQLtoSQLite._translate_default_from_mysql_to_sqlite("curtime()") == "DEFAULT CURRENT_TIME"
+        assert MySQLtoSQLite._translate_default_from_mysql_to_sqlite("CURTIME()") == "DEFAULT CURRENT_TIME"
+
+    def test_translate_default_from_mysql_to_sqlite_curdate(self) -> None:
+        """Test _translate_default_from_mysql_to_sqlite with curdate()."""
+        assert MySQLtoSQLite._translate_default_from_mysql_to_sqlite("curdate()") == "DEFAULT CURRENT_DATE"
+        assert MySQLtoSQLite._translate_default_from_mysql_to_sqlite("CURDATE()") == "DEFAULT CURRENT_DATE"
+
+    def test_translate_default_from_mysql_to_sqlite_current_timestamp_with_parentheses(self) -> None:
+        """Test _translate_default_from_mysql_to_sqlite with current_timestamp()."""
+        assert MySQLtoSQLite._translate_default_from_mysql_to_sqlite("current_timestamp()") == "DEFAULT CURRENT_TIMESTAMP"
+        assert MySQLtoSQLite._translate_default_from_mysql_to_sqlite("CURRENT_TIMESTAMP()") == "DEFAULT CURRENT_TIMESTAMP"
+
+    def test_translate_default_from_mysql_to_sqlite_now(self) -> None:
+        """Test _translate_default_from_mysql_to_sqlite with now()."""
+        assert MySQLtoSQLite._translate_default_from_mysql_to_sqlite("now()") == "DEFAULT CURRENT_TIMESTAMP"
+        assert MySQLtoSQLite._translate_default_from_mysql_to_sqlite("NOW()") == "DEFAULT CURRENT_TIMESTAMP"

--- a/tests/unit/test_transporter.py
+++ b/tests/unit/test_transporter.py
@@ -238,8 +238,12 @@ class TestMySQLtoSQLiteTransporter:
 
     def test_translate_default_from_mysql_to_sqlite_current_timestamp_with_parentheses(self) -> None:
         """Test _translate_default_from_mysql_to_sqlite with current_timestamp()."""
-        assert MySQLtoSQLite._translate_default_from_mysql_to_sqlite("current_timestamp()") == "DEFAULT CURRENT_TIMESTAMP"
-        assert MySQLtoSQLite._translate_default_from_mysql_to_sqlite("CURRENT_TIMESTAMP()") == "DEFAULT CURRENT_TIMESTAMP"
+        assert (
+            MySQLtoSQLite._translate_default_from_mysql_to_sqlite("current_timestamp()") == "DEFAULT CURRENT_TIMESTAMP"
+        )
+        assert (
+            MySQLtoSQLite._translate_default_from_mysql_to_sqlite("CURRENT_TIMESTAMP()") == "DEFAULT CURRENT_TIMESTAMP"
+        )
 
     def test_translate_default_from_mysql_to_sqlite_now(self) -> None:
         """Test _translate_default_from_mysql_to_sqlite with now()."""


### PR DESCRIPTION
This pull request introduces a new feature to defer foreign key constraints during the transfer process from MySQL to SQLite, along with validation for foreign key constraints after the transfer. It also includes related updates to the CLI, transporter logic, and type definitions. Below is a summary of the most important changes:

### New Feature: Deferred Foreign Key Constraints

* Added a new CLI option `-D/--defer-foreign-keys` to allow deferring foreign key constraints until the end of the transfer. This ensures better handling of foreign key dependencies during the transfer process. (`src/mysql_to_sqlite3/cli.py`, [[1]](diffhunk://#diff-4d9a05537708ba0ed7a576a03cf61ef0d3412a00237958cdaace44bbf1473bd6R96-R98) [[2]](diffhunk://#diff-4d9a05537708ba0ed7a576a03cf61ef0d3412a00237958cdaace44bbf1473bd6R170) [[3]](diffhunk://#diff-4d9a05537708ba0ed7a576a03cf61ef0d3412a00237958cdaace44bbf1473bd6R219-R223)

* Updated the transporter logic to support the `defer_foreign_keys` option. If enabled, foreign keys are marked as `DEFERRABLE INITIALLY DEFERRED` in the generated SQLite schema, provided the SQLite version supports it. (`src/mysql_to_sqlite3/transporter.py`, [[1]](diffhunk://#diff-d587de84fe5843f8b7da9d907fdf926d59b827751de153e18ae6d6195d090a73R98-R107) [[2]](diffhunk://#diff-d587de84fe5843f8b7da9d907fdf926d59b827751de153e18ae6d6195d090a73R570-R575)

### Validation of Foreign Key Constraints

* Added validation for foreign key constraints after the transfer is complete. If violations are detected, they are logged with details about the affected tables and rows. (`src/mysql_to_sqlite3/transporter.py`, [src/mysql_to_sqlite3/transporter.pyR770-R795](diffhunk://#diff-d587de84fe5843f8b7da9d907fdf926d59b827751de153e18ae6d6195d090a73R770-R795))

### Type Definitions and Tests

* Updated type definitions in `MySQLtoSQLiteParams` and `MySQLtoSQLiteAttributes` to include the new `defer_foreign_keys` attribute. (`src/mysql_to_sqlite3/types.py`, [[1]](diffhunk://#diff-e3e37babd965625bcc5103cdd3355eb8e0273ce898b7c69542e5ba147d15448aR38) [[2]](diffhunk://#diff-e3e37babd965625bcc5103cdd3355eb8e0273ce898b7c69542e5ba147d15448aR75)

* Updated unit tests to verify the behavior of foreign key validation by replacing the call to `PRAGMA foreign_keys=ON` with `PRAGMA foreign_key_check`. (`tests/unit/test_transporter.py`, [tests/unit/test_transporter.pyL153-R153](diffhunk://#diff-e5baf2276fe86dcf71060700385857aca6075065a73f9aa5d9c16087d8688df2L153-R153))