### PR TITLE
:safety_vest: add support for SQLite STRICT tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Options:
   -X, --without-foreign-keys      Do not transfer foreign keys.
   -Z, --without-tables            Do not transfer tables, data only.
   -W, --without-data              Do not transfer table data, DDL only.
+  -M, --strict                    Create SQLite STRICT tables when supported.
   -h, --mysql-host TEXT           MySQL host. Defaults to localhost.
   -P, --mysql-port INTEGER        MySQL port. Defaults to 3306.
   --mysql-charset TEXT            MySQL database and table character set

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -38,6 +38,7 @@ Transfer Options
 - ``-X, --without-foreign-keys``: Do not transfer foreign keys.
 - ``-Z, --without-tables``: Do not transfer tables, data only.
 - ``-W, --without-data``: Do not transfer table data, DDL only.
+- ``-M, --strict``: Create SQLite STRICT tables when supported.
 
 Connection Options
 """"""""""""""""""

--- a/src/mysql_to_sqlite3/cli.py
+++ b/src/mysql_to_sqlite3/cli.py
@@ -144,6 +144,12 @@ _copyright_header: str = f"mysql2sqlite version {package_version} Copyright (c) 
     "repacking it into a minimal amount of disk space",
 )
 @click.option(
+    "-M",
+    "--strict",
+    is_flag=True,
+    help="Create SQLite STRICT tables when supported.",
+)
+@click.option(
     "--use-buffered-cursors",
     is_flag=True,
     help="Use MySQLCursorBuffered for reading the MySQL database. This "
@@ -176,6 +182,7 @@ def cli(
     log_file: t.Union[str, "os.PathLike[t.Any]"],
     json_as_text: bool,
     vacuum: bool,
+    strict: bool,
     use_buffered_cursors: bool,
     quiet: bool,
     debug: bool,
@@ -223,6 +230,7 @@ def cli(
             chunk=chunk,
             json_as_text=json_as_text,
             vacuum=vacuum,
+            sqlite_strict=strict,
             buffered=use_buffered_cursors,
             log_file=log_file,
             quiet=quiet,

--- a/src/mysql_to_sqlite3/cli.py
+++ b/src/mysql_to_sqlite3/cli.py
@@ -106,6 +106,12 @@ _copyright_header: str = f"mysql2sqlite version {package_version} Copyright (c) 
     is_flag=True,
     help="Do not transfer table data, DDL only.",
 )
+@click.option(
+    "-M",
+    "--strict",
+    is_flag=True,
+    help="Create SQLite STRICT tables when supported.",
+)
 @click.option("-h", "--mysql-host", default="localhost", help="MySQL host. Defaults to localhost.")
 @click.option("-P", "--mysql-port", type=int, default=3306, help="MySQL port. Defaults to 3306.")
 @click.option(
@@ -144,12 +150,6 @@ _copyright_header: str = f"mysql2sqlite version {package_version} Copyright (c) 
     "repacking it into a minimal amount of disk space",
 )
 @click.option(
-    "-M",
-    "--strict",
-    is_flag=True,
-    help="Create SQLite STRICT tables when supported.",
-)
-@click.option(
     "--use-buffered-cursors",
     is_flag=True,
     help="Use MySQLCursorBuffered for reading the MySQL database. This "
@@ -173,6 +173,7 @@ def cli(
     without_foreign_keys: bool,
     without_tables: bool,
     without_data: bool,
+    strict: bool,
     mysql_host: str,
     mysql_port: int,
     mysql_charset: str,
@@ -182,7 +183,6 @@ def cli(
     log_file: t.Union[str, "os.PathLike[t.Any]"],
     json_as_text: bool,
     vacuum: bool,
-    strict: bool,
     use_buffered_cursors: bool,
     quiet: bool,
     debug: bool,
@@ -222,6 +222,7 @@ def cli(
             without_foreign_keys=without_foreign_keys or bool(mysql_tables) or bool(exclude_mysql_tables),
             without_tables=without_tables,
             without_data=without_data,
+            sqlite_strict=strict,
             mysql_host=mysql_host,
             mysql_port=mysql_port,
             mysql_charset=mysql_charset,
@@ -230,7 +231,6 @@ def cli(
             chunk=chunk,
             json_as_text=json_as_text,
             vacuum=vacuum,
-            sqlite_strict=strict,
             buffered=use_buffered_cursors,
             log_file=log_file,
             quiet=quiet,

--- a/src/mysql_to_sqlite3/types.py
+++ b/src/mysql_to_sqlite3/types.py
@@ -39,6 +39,7 @@ class MySQLtoSQLiteParams(TypedDict):
     prefix_indices: t.Optional[bool]
     quiet: t.Optional[bool]
     sqlite_file: t.Union[str, "os.PathLike[t.Any]"]
+    sqlite_strict: t.Optional[bool]
     vacuum: t.Optional[bool]
     without_tables: t.Optional[bool]
     without_data: t.Optional[bool]
@@ -74,6 +75,7 @@ class MySQLtoSQLiteAttributes:
     _sqlite: Connection
     _sqlite_cur: Cursor
     _sqlite_file: t.Union[str, "os.PathLike[t.Any]"]
+    _sqlite_strict: bool
     _without_tables: bool
     _sqlite_json1_extension_enabled: bool
     _vacuum: bool


### PR DESCRIPTION
This pull request adds support for creating SQLite tables in STRICT mode when the SQLite version supports it. A new CLI option is introduced to enable this feature, and appropriate checks and warnings are implemented for unsupported SQLite versions. The documentation is updated, and unit tests are added to ensure correct behavior.

**New STRICT mode support:**

* Added a `--strict` (`-M`) CLI option to enable creation of SQLite STRICT tables when supported. This is reflected in both the CLI argument parsing (`cli.py`) and the documentation (`README.md`, `docs/README.rst`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R63) [[2]](diffhunk://#diff-bd548e7db9014f8f260e91e07e0cd7656294babd0f3fecabf215b561b9e11efcR41) [[3]](diffhunk://#diff-4d9a05537708ba0ed7a576a03cf61ef0d3412a00237958cdaace44bbf1473bd6R109-R114) [[4]](diffhunk://#diff-4d9a05537708ba0ed7a576a03cf61ef0d3412a00237958cdaace44bbf1473bd6R176)
* The `MySQLtoSQLite` class now accepts a `sqlite_strict` parameter, stores it as an attribute, and checks the SQLite version. If STRICT mode is requested but not supported (SQLite < 3.37.0), a warning is logged and STRICT mode is disabled. [[1]](diffhunk://#diff-d587de84fe5843f8b7da9d907fdf926d59b827751de153e18ae6d6195d090a73R123-R133) [[2]](diffhunk://#diff-e3e37babd965625bcc5103cdd3355eb8e0273ce898b7c69542e5ba147d15448aR42) [[3]](diffhunk://#diff-e3e37babd965625bcc5103cdd3355eb8e0273ce898b7c69542e5ba147d15448aR78)
* When enabled, STRICT is appended to `CREATE TABLE` statements in the generated SQL.

**Testing and validation:**

* Added unit tests to verify that STRICT mode is enabled or disabled appropriately based on the SQLite version, and that the correct warnings are issued. Also tests that STRICT is appended to `CREATE TABLE` statements when enabled.
* Updated test imports to support new tests.

---

Closes #106