### PR TITLE
:sparkles: add MySQL SSL certificate options (--mysql-ssl-ca, --mysql-ssl-cert, --mysql-ssl-key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Options:
   --mysql-charset TEXT            MySQL database and table character set
                                   [default: utf8mb4]
   --mysql-collation TEXT          MySQL database and table collation
+  --mysql-ssl-ca PATH             Path to SSL CA certificate file.
+  --mysql-ssl-cert PATH           Path to SSL certificate file.
+  --mysql-ssl-key PATH            Path to SSL key file.
   -S, --skip-ssl                  Disable MySQL connection encryption.
   -c, --chunk INTEGER             Chunk reading/writing SQL records
   -l, --log-file PATH             Log file

--- a/README.md
+++ b/README.md
@@ -71,8 +71,13 @@ Options:
   --mysql-collation TEXT          MySQL database and table collation
   --mysql-ssl-ca PATH             Path to SSL CA certificate file.
   --mysql-ssl-cert PATH           Path to SSL certificate file.
+                                  Must be provided together with
+                                  --mysql-ssl-key.
   --mysql-ssl-key PATH            Path to SSL key file.
+                                  Must be provided together with
+                                  --mysql-ssl-cert.
   -S, --skip-ssl                  Disable MySQL connection encryption.
+                                  Cannot be used with --mysql-ssl-* options.
   -c, --chunk INTEGER             Chunk reading/writing SQL records
   -l, --log-file PATH             Log file
   --json-as-text                  Transfer JSON columns as TEXT.

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -49,9 +49,9 @@ Connection Options
 - ``--mysql-charset TEXT``: MySQL database and table character set. The default is utf8mb4.
 - ``--mysql-collation TEXT``: MySQL database and table collation.
 - ``--mysql-ssl-ca PATH``: Path to SSL CA certificate file.
-- ``--mysql-ssl-cert PATH``: Path to SSL certificate file.
-- ``--mysql-ssl-key PATH``: Path to SSL key file.
-- ``-S, --skip-ssl``: Disable MySQL connection encryption.
+- ``--mysql-ssl-cert PATH``: Path to SSL certificate file. Must be provided together with ``--mysql-ssl-key``.
+- ``--mysql-ssl-key PATH``: Path to SSL key file. Must be provided together with ``--mysql-ssl-cert``.
+- ``-S, --skip-ssl``: Disable MySQL connection encryption. Cannot be used together with ``--mysql-ssl-*`` options.
 
 Other Options
 """""""""""""

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -47,7 +47,10 @@ Connection Options
 - ``-h, --mysql-host TEXT``: MySQL host. Defaults to localhost.
 - ``-P, --mysql-port INTEGER``: MySQL port. Defaults to 3306.
 - ``--mysql-charset TEXT``: MySQL database and table character set. The default is utf8mb4.
-- ``--mysql-collation TEXT``: MySQL database and table collation
+- ``--mysql-collation TEXT``: MySQL database and table collation.
+- ``--mysql-ssl-ca PATH``: Path to SSL CA certificate file.
+- ``--mysql-ssl-cert PATH``: Path to SSL certificate file.
+- ``--mysql-ssl-key PATH``: Path to SSL key file.
 - ``-S, --skip-ssl``: Disable MySQL connection encryption.
 
 Other Options

--- a/src/mysql_to_sqlite3/cli.py
+++ b/src/mysql_to_sqlite3/cli.py
@@ -137,6 +137,9 @@ _copyright_header: str = f"mysql2sqlite version {package_version} Copyright (c) 
     default=None,
     help="MySQL database and table collation",
 )
+@click.option("--mysql-ssl-ca", type=click.Path(), default=None, help="Path to SSL CA certificate file.")
+@click.option("--mysql-ssl-cert", type=click.Path(), default=None, help="Path to SSL certificate file.")
+@click.option("--mysql-ssl-key", type=click.Path(), default=None, help="Path to SSL key file.")
 @click.option("-S", "--skip-ssl", is_flag=True, help="Disable MySQL connection encryption.")
 @click.option(
     "-c",
@@ -184,6 +187,9 @@ def cli(
     mysql_port: int,
     mysql_charset: str,
     mysql_collation: str,
+    mysql_ssl_ca: t.Optional[str],
+    mysql_ssl_cert: t.Optional[str],
+    mysql_ssl_key: t.Optional[str],
     skip_ssl: bool,
     chunk: int,
     log_file: t.Union[str, "os.PathLike[t.Any]"],
@@ -234,6 +240,9 @@ def cli(
             mysql_port=mysql_port,
             mysql_charset=mysql_charset,
             mysql_collation=mysql_collation,
+            mysql_ssl_ca=mysql_ssl_ca,
+            mysql_ssl_cert=mysql_ssl_cert,
+            mysql_ssl_key=mysql_ssl_key,
             mysql_ssl_disabled=skip_ssl,
             chunk=chunk,
             json_as_text=json_as_text,

--- a/src/mysql_to_sqlite3/cli.py
+++ b/src/mysql_to_sqlite3/cli.py
@@ -137,9 +137,24 @@ _copyright_header: str = f"mysql2sqlite version {package_version} Copyright (c) 
     default=None,
     help="MySQL database and table collation",
 )
-@click.option("--mysql-ssl-ca", type=click.Path(), default=None, help="Path to SSL CA certificate file.")
-@click.option("--mysql-ssl-cert", type=click.Path(), default=None, help="Path to SSL certificate file.")
-@click.option("--mysql-ssl-key", type=click.Path(), default=None, help="Path to SSL key file.")
+@click.option(
+    "--mysql-ssl-ca",
+    type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True),
+    default=None,
+    help="Path to SSL CA certificate file.",
+)
+@click.option(
+    "--mysql-ssl-cert",
+    type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True),
+    default=None,
+    help="Path to SSL certificate file.",
+)
+@click.option(
+    "--mysql-ssl-key",
+    type=click.Path(exists=True, dir_okay=False, file_okay=True, readable=True),
+    default=None,
+    help="Path to SSL key file.",
+)
 @click.option("-S", "--skip-ssl", is_flag=True, help="Disable MySQL connection encryption.")
 @click.option(
     "-c",
@@ -220,6 +235,16 @@ def cli(
 
         if mysql_tables is not None and exclude_mysql_tables is not None:
             raise click.UsageError("Illegal usage: --mysql-tables and --exclude-mysql-tables are mutually exclusive!")
+
+        if skip_ssl and any((mysql_ssl_ca, mysql_ssl_cert, mysql_ssl_key)):
+            raise click.UsageError(
+                "Illegal usage: --skip-ssl and --mysql-ssl-ca/--mysql-ssl-cert/--mysql-ssl-key are mutually exclusive!"
+            )
+
+        if bool(mysql_ssl_cert) != bool(mysql_ssl_key):
+            raise click.UsageError(
+                "Illegal usage: --mysql-ssl-cert and --mysql-ssl-key must be provided together."
+            )
 
         converter = MySQLtoSQLite(
             sqlite_file=sqlite_file,

--- a/src/mysql_to_sqlite3/transporter.py
+++ b/src/mysql_to_sqlite3/transporter.py
@@ -110,6 +110,9 @@ class MySQLtoSQLite(MySQLtoSQLiteAttributes):
         if self._without_tables and self._without_data:
             raise ValueError("Unable to continue without transferring data or creating tables!")
 
+        self._mysql_ssl_ca = kwargs.get("mysql_ssl_ca") or None
+        self._mysql_ssl_cert = kwargs.get("mysql_ssl_cert") or None
+        self._mysql_ssl_key = kwargs.get("mysql_ssl_key") or None
         self._mysql_ssl_disabled = bool(kwargs.get("mysql_ssl_disabled", False))
 
         self._current_chunk_number = 0
@@ -161,6 +164,9 @@ class MySQLtoSQLite(MySQLtoSQLiteAttributes):
                 password=self._mysql_password,
                 host=self._mysql_host,
                 port=self._mysql_port,
+                ssl_ca=self._mysql_ssl_ca,
+                ssl_cert=self._mysql_ssl_cert,
+                ssl_key=self._mysql_ssl_key,
                 ssl_disabled=self._mysql_ssl_disabled,
                 charset=self._mysql_charset,
                 collation=self._mysql_collation,

--- a/src/mysql_to_sqlite3/transporter.py
+++ b/src/mysql_to_sqlite3/transporter.py
@@ -115,6 +115,12 @@ class MySQLtoSQLite(MySQLtoSQLiteAttributes):
         self._mysql_ssl_key = kwargs.get("mysql_ssl_key") or None
         self._mysql_ssl_disabled = bool(kwargs.get("mysql_ssl_disabled", False))
 
+        if self._mysql_ssl_disabled and any((self._mysql_ssl_ca, self._mysql_ssl_cert, self._mysql_ssl_key)):
+            raise ValueError("Cannot use SSL certificate options when SSL is disabled")
+
+        if bool(self._mysql_ssl_cert) != bool(self._mysql_ssl_key):
+            raise ValueError("mysql_ssl_cert and mysql_ssl_key must be provided together")
+
         self._current_chunk_number = 0
 
         self._chunk_size = kwargs.get("chunk") or None

--- a/src/mysql_to_sqlite3/transporter.py
+++ b/src/mysql_to_sqlite3/transporter.py
@@ -173,6 +173,7 @@ class MySQLtoSQLite(MySQLtoSQLiteAttributes):
                 ssl_ca=self._mysql_ssl_ca,
                 ssl_cert=self._mysql_ssl_cert,
                 ssl_key=self._mysql_ssl_key,
+                ssl_verify_cert=self._mysql_ssl_ca is not None,
                 ssl_disabled=self._mysql_ssl_disabled,
                 charset=self._mysql_charset,
                 collation=self._mysql_collation,

--- a/src/mysql_to_sqlite3/types.py
+++ b/src/mysql_to_sqlite3/types.py
@@ -32,6 +32,9 @@ class MySQLtoSQLiteParams(TypedDict):
     mysql_port: int
     mysql_charset: t.Optional[str]
     mysql_collation: t.Optional[str]
+    mysql_ssl_ca: t.Optional[str]
+    mysql_ssl_cert: t.Optional[str]
+    mysql_ssl_key: t.Optional[str]
     mysql_ssl_disabled: t.Optional[bool]
     mysql_tables: t.Optional[t.Sequence[str]]
     mysql_user: str
@@ -67,6 +70,9 @@ class MySQLtoSQLiteAttributes:
     _mysql_port: int
     _mysql_charset: str
     _mysql_collation: str
+    _mysql_ssl_ca: t.Optional[str]
+    _mysql_ssl_cert: t.Optional[str]
+    _mysql_ssl_key: t.Optional[str]
     _mysql_ssl_disabled: bool
     _mysql_tables: t.Sequence[str]
     _mysql_user: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -295,56 +295,60 @@ def mysql_ssl_certs(
         return None
 
     client: DockerClient = docker.from_env()
-    container: t.Optional[Container] = None
-    for c in client.containers.list():
-        if c.name == "pytest_mysql_to_sqlite3":
-            container = c
-            break
+    try:
+        container: t.Optional[Container] = None
+        for c in client.containers.list():
+            if c.name == "pytest_mysql_to_sqlite3":
+                container = c
+                break
 
-    if container is None:
-        pytest.fail("MySQL test container is running, but SSL cert extraction could not find it")
+        if container is None:
+            pytest.fail("MySQL test container is running, but SSL cert extraction could not find it")
 
-    ssl_dir = tmp_path_factory.mktemp("mysql_ssl_certs")
+        ssl_dir = tmp_path_factory.mktemp("mysql_ssl_certs")
 
-    cert_files = {
-        "ca.pem": "ca.pem",
-        "client-cert.pem": "client-cert.pem",
-        "client-key.pem": "client-key.pem",
-    }
+        cert_files = {
+            "ca.pem": "ca.pem",
+            "client-cert.pem": "client-cert.pem",
+            "client-key.pem": "client-key.pem",
+        }
 
-    extracted: t.Dict[str, str] = {}
-    for filename, dest_name in cert_files.items():
-        try:
-            data_stream, _stat = container.get_archive(f"/var/lib/mysql/{filename}")
-        except NotFound:
-            # Cert files not present - MySQL version likely doesn't auto-generate them
-            return None
+        extracted: t.Dict[str, str] = {}
+        for filename, dest_name in cert_files.items():
+            try:
+                data_stream, _stat = container.get_archive(f"/var/lib/mysql/{filename}")
+            except NotFound:
+                # Cert files not present - MySQL version likely doesn't auto-generate them
+                return None
 
-        buf = io.BytesIO()
-        for chunk in data_stream:
-            buf.write(chunk)
-        buf.seek(0)
-        with tarfile.open(fileobj=buf) as tar:
-            member = next(
-                (m for m in tar.getmembers() if Path(m.name).name == filename),
-                None,
-            )
-            if member is None:
-                pytest.fail(f"Docker returned an archive for {filename}, but the file was not present")
+            buf = io.BytesIO()
+            for chunk in data_stream:
+                buf.write(chunk)
+            buf.seek(0)
+            with tarfile.open(fileobj=buf) as tar:
+                member = next(
+                    (m for m in tar.getmembers() if Path(m.name).name == filename),
+                    None,
+                )
+                if member is None:
+                    pytest.fail(f"Docker returned an archive for {filename}, but the file was not present")
 
-            fobj = tar.extractfile(member)
-            if fobj is None:
-                pytest.fail(f"Could not read {filename} from the Docker archive")
+                fobj = tar.extractfile(member)
+                if fobj is None:
+                    pytest.fail(f"Could not read {filename} from the Docker archive")
 
-            dest_path = ssl_dir / dest_name
-            dest_path.write_bytes(fobj.read())
-            extracted[filename] = str(dest_path)
+                with fobj:
+                    dest_path = ssl_dir / dest_name
+                    dest_path.write_bytes(fobj.read())
+                    extracted[filename] = str(dest_path)
 
-    return MySQLSSLCerts(
-        ca=extracted["ca.pem"],
-        client_cert=extracted["client-cert.pem"],
-        client_key=extracted["client-key.pem"],
-    )
+        return MySQLSSLCerts(
+            ca=extracted["ca.pem"],
+            client_cert=extracted["client-cert.pem"],
+            client_key=extracted["client-key.pem"],
+        )
+    finally:
+        client.close()
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -294,48 +294,57 @@ def mysql_ssl_certs(
     if not pytestconfig.getoption("use_docker"):
         return None
 
-    try:
-        client: DockerClient = docker.from_env()
-        container: t.Optional[Container] = None
-        for c in client.containers.list():
-            if c.name == "pytest_mysql_to_sqlite3":
-                container = c
-                break
+    client: DockerClient = docker.from_env()
+    container: t.Optional[Container] = None
+    for c in client.containers.list():
+        if c.name == "pytest_mysql_to_sqlite3":
+            container = c
+            break
 
-        if container is None:
+    if container is None:
+        return None
+
+    ssl_dir = tmp_path_factory.mktemp("mysql_ssl_certs")
+
+    cert_files = {
+        "ca.pem": "ca.pem",
+        "client-cert.pem": "client-cert.pem",
+        "client-key.pem": "client-key.pem",
+    }
+
+    extracted: t.Dict[str, str] = {}
+    for filename, dest_name in cert_files.items():
+        try:
+            data_stream, _stat = container.get_archive(f"/var/lib/mysql/{filename}")
+        except NotFound:
+            # Cert files not present - MySQL version likely doesn't auto-generate them
             return None
 
-        ssl_dir = tmp_path_factory.mktemp("mysql_ssl_certs")
+        buf = io.BytesIO()
+        for chunk in data_stream:
+            buf.write(chunk)
+        buf.seek(0)
+        with tarfile.open(fileobj=buf) as tar:
+            member = next(
+                (m for m in tar.getmembers() if Path(m.name).name == filename),
+                None,
+            )
+            if member is None:
+                return None
 
-        cert_files = {
-            "ca.pem": "ca.pem",
-            "client-cert.pem": "client-cert.pem",
-            "client-key.pem": "client-key.pem",
-        }
+            fobj = tar.extractfile(member)
+            if fobj is None:
+                return None
 
-        extracted: t.Dict[str, str] = {}
-        for filename, dest_name in cert_files.items():
-            data_stream, _stat = container.get_archive(f"/var/lib/mysql/{filename}")
-            buf = io.BytesIO()
-            for chunk in data_stream:
-                buf.write(chunk)
-            buf.seek(0)
-            with tarfile.open(fileobj=buf) as tar:
-                member = tar.getmember(filename)
-                fobj = tar.extractfile(member)
-                if fobj is None:
-                    return None
-                dest_path = ssl_dir / dest_name
-                dest_path.write_bytes(fobj.read())
-                extracted[filename] = str(dest_path)
+            dest_path = ssl_dir / dest_name
+            dest_path.write_bytes(fobj.read())
+            extracted[filename] = str(dest_path)
 
-        return MySQLSSLCerts(
-            ca=extracted["ca.pem"],
-            client_cert=extracted["client-cert.pem"],
-            client_key=extracted["client-key.pem"],
-        )
-    except Exception:
-        return None
+    return MySQLSSLCerts(
+        ca=extracted["ca.pem"],
+        client_cert=extracted["client-cert.pem"],
+        client_key=extracted["client-key.pem"],
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
+import io
 import json
 import os
 import socket
+import tarfile
 import typing as t
 from codecs import open
 from contextlib import contextmanager
@@ -269,6 +271,71 @@ def mysql_instance(mysql_credentials: MySQLCredentials, pytestconfig: Config) ->
 
     if use_docker and container is not None:
         container.kill()
+
+
+class MySQLSSLCerts(t.NamedTuple):
+    """Paths to MySQL SSL certificate files extracted from the Docker container."""
+
+    ca: str
+    client_cert: str
+    client_key: str
+
+
+@pytest.fixture(scope="session")
+def mysql_ssl_certs(
+    mysql_instance: MySQLConnection,
+    pytestconfig: Config,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> t.Optional[MySQLSSLCerts]:
+    db_credentials_file = abspath(join(dirname(__file__), "db_credentials.json"))
+    if isfile(db_credentials_file):
+        return None
+
+    if not pytestconfig.getoption("use_docker"):
+        return None
+
+    try:
+        client: DockerClient = docker.from_env()
+        container: t.Optional[Container] = None
+        for c in client.containers.list():
+            if c.name == "pytest_mysql_to_sqlite3":
+                container = c
+                break
+
+        if container is None:
+            return None
+
+        ssl_dir = tmp_path_factory.mktemp("mysql_ssl_certs")
+
+        cert_files = {
+            "ca.pem": "ca.pem",
+            "client-cert.pem": "client-cert.pem",
+            "client-key.pem": "client-key.pem",
+        }
+
+        extracted: t.Dict[str, str] = {}
+        for filename, dest_name in cert_files.items():
+            data_stream, _stat = container.get_archive(f"/var/lib/mysql/{filename}")
+            buf = io.BytesIO()
+            for chunk in data_stream:
+                buf.write(chunk)
+            buf.seek(0)
+            with tarfile.open(fileobj=buf) as tar:
+                member = tar.getmember(filename)
+                fobj = tar.extractfile(member)
+                if fobj is None:
+                    return None
+                dest_path = ssl_dir / dest_name
+                dest_path.write_bytes(fobj.read())
+                extracted[filename] = str(dest_path)
+
+        return MySQLSSLCerts(
+            ca=extracted["ca.pem"],
+            client_cert=extracted["client-cert.pem"],
+            client_key=extracted["client-key.pem"],
+        )
+    except Exception:
+        return None
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -302,7 +302,7 @@ def mysql_ssl_certs(
             break
 
     if container is None:
-        return None
+        pytest.fail("MySQL test container is running, but SSL cert extraction could not find it")
 
     ssl_dir = tmp_path_factory.mktemp("mysql_ssl_certs")
 
@@ -330,11 +330,11 @@ def mysql_ssl_certs(
                 None,
             )
             if member is None:
-                return None
+                pytest.fail(f"Docker returned an archive for {filename}, but the file was not present")
 
             fobj = tar.extractfile(member)
             if fobj is None:
-                return None
+                pytest.fail(f"Could not read {filename} from the Docker archive")
 
             dest_path = ssl_dir / dest_name
             dest_path.write_bytes(fobj.read())

--- a/tests/func/test_cli.py
+++ b/tests/func/test_cli.py
@@ -773,10 +773,10 @@ class TestMySQLtoSQLiteSSL:
         self,
         cli_runner: CliRunner,
         sqlite_database: "os.PathLike[t.Any]",
-        mysql_database: Database,
         mysql_credentials: MySQLCredentials,
         mysql_ssl_certs: t.Optional["MySQLSSLCerts"],
     ) -> None:
+        """SSL cert without key should be rejected at CLI validation."""
         if mysql_ssl_certs is None:
             pytest.skip("SSL certs not available for this environment")
         result: Result = cli_runner.invoke(
@@ -794,22 +794,21 @@ class TestMySQLtoSQLiteSSL:
                 mysql_credentials.host,
                 "-P",
                 str(mysql_credentials.port),
-                "--mysql-ssl-ca",
-                str(mysql_ssl_certs.ca),
                 "--mysql-ssl-cert",
                 str(mysql_ssl_certs.client_cert),
             ],
         )
         assert result.exit_code > 0
+        assert "must be provided together" in result.output
 
     def test_ssl_connection_key_without_cert_fails(
         self,
         cli_runner: CliRunner,
         sqlite_database: "os.PathLike[t.Any]",
-        mysql_database: Database,
         mysql_credentials: MySQLCredentials,
         mysql_ssl_certs: t.Optional["MySQLSSLCerts"],
     ) -> None:
+        """SSL key without cert should be rejected at CLI validation."""
         if mysql_ssl_certs is None:
             pytest.skip("SSL certs not available for this environment")
         result: Result = cli_runner.invoke(
@@ -827,10 +826,9 @@ class TestMySQLtoSQLiteSSL:
                 mysql_credentials.host,
                 "-P",
                 str(mysql_credentials.port),
-                "--mysql-ssl-ca",
-                str(mysql_ssl_certs.ca),
                 "--mysql-ssl-key",
                 str(mysql_ssl_certs.client_key),
             ],
         )
         assert result.exit_code > 0
+        assert "must be provided together" in result.output

--- a/tests/func/test_cli.py
+++ b/tests/func/test_cli.py
@@ -12,7 +12,7 @@ from sqlalchemy import Connection, Engine, Inspector, create_engine, inspect
 from mysql_to_sqlite3 import MySQLtoSQLite
 from mysql_to_sqlite3 import __version__ as package_version
 from mysql_to_sqlite3.cli import cli as mysql2sqlite
-from tests.conftest import MySQLCredentials
+from tests.conftest import MySQLCredentials, MySQLSSLCerts
 from tests.database import Database
 
 
@@ -665,3 +665,172 @@ class TestMySQLtoSQLite:
             ],
         )
         assert "using password: NO" in result.output
+
+
+@pytest.mark.cli
+@pytest.mark.usefixtures("mysql_instance")
+class TestMySQLtoSQLiteSSL:
+    def test_ssl_connection_with_all_options(
+        self,
+        cli_runner: CliRunner,
+        sqlite_database: "os.PathLike[t.Any]",
+        mysql_database: Database,
+        mysql_credentials: MySQLCredentials,
+        mysql_ssl_certs: t.Optional["MySQLSSLCerts"],
+    ) -> None:
+        if mysql_ssl_certs is None:
+            pytest.skip("SSL certs not available for this environment")
+        result: Result = cli_runner.invoke(
+            mysql2sqlite,
+            [
+                "-f",
+                str(sqlite_database),
+                "-d",
+                mysql_credentials.database,
+                "-u",
+                mysql_credentials.user,
+                "--mysql-password",
+                mysql_credentials.password,
+                "-h",
+                mysql_credentials.host,
+                "-P",
+                str(mysql_credentials.port),
+                "--mysql-ssl-ca",
+                str(mysql_ssl_certs.ca),
+                "--mysql-ssl-cert",
+                str(mysql_ssl_certs.client_cert),
+                "--mysql-ssl-key",
+                str(mysql_ssl_certs.client_key),
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_ssl_connection_ca_only(
+        self,
+        cli_runner: CliRunner,
+        sqlite_database: "os.PathLike[t.Any]",
+        mysql_database: Database,
+        mysql_credentials: MySQLCredentials,
+        mysql_ssl_certs: t.Optional["MySQLSSLCerts"],
+    ) -> None:
+        if mysql_ssl_certs is None:
+            pytest.skip("SSL certs not available for this environment")
+        result: Result = cli_runner.invoke(
+            mysql2sqlite,
+            [
+                "-f",
+                str(sqlite_database),
+                "-d",
+                mysql_credentials.database,
+                "-u",
+                mysql_credentials.user,
+                "--mysql-password",
+                mysql_credentials.password,
+                "-h",
+                mysql_credentials.host,
+                "-P",
+                str(mysql_credentials.port),
+                "--mysql-ssl-ca",
+                str(mysql_ssl_certs.ca),
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_ssl_connection_cert_and_key_without_ca(
+        self,
+        cli_runner: CliRunner,
+        sqlite_database: "os.PathLike[t.Any]",
+        mysql_database: Database,
+        mysql_credentials: MySQLCredentials,
+        mysql_ssl_certs: t.Optional["MySQLSSLCerts"],
+    ) -> None:
+        if mysql_ssl_certs is None:
+            pytest.skip("SSL certs not available for this environment")
+        result: Result = cli_runner.invoke(
+            mysql2sqlite,
+            [
+                "-f",
+                str(sqlite_database),
+                "-d",
+                mysql_credentials.database,
+                "-u",
+                mysql_credentials.user,
+                "--mysql-password",
+                mysql_credentials.password,
+                "-h",
+                mysql_credentials.host,
+                "-P",
+                str(mysql_credentials.port),
+                "--mysql-ssl-cert",
+                str(mysql_ssl_certs.client_cert),
+                "--mysql-ssl-key",
+                str(mysql_ssl_certs.client_key),
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_ssl_connection_cert_without_key_fails(
+        self,
+        cli_runner: CliRunner,
+        sqlite_database: "os.PathLike[t.Any]",
+        mysql_database: Database,
+        mysql_credentials: MySQLCredentials,
+        mysql_ssl_certs: t.Optional["MySQLSSLCerts"],
+    ) -> None:
+        if mysql_ssl_certs is None:
+            pytest.skip("SSL certs not available for this environment")
+        result: Result = cli_runner.invoke(
+            mysql2sqlite,
+            [
+                "-f",
+                str(sqlite_database),
+                "-d",
+                mysql_credentials.database,
+                "-u",
+                mysql_credentials.user,
+                "--mysql-password",
+                mysql_credentials.password,
+                "-h",
+                mysql_credentials.host,
+                "-P",
+                str(mysql_credentials.port),
+                "--mysql-ssl-ca",
+                str(mysql_ssl_certs.ca),
+                "--mysql-ssl-cert",
+                str(mysql_ssl_certs.client_cert),
+            ],
+        )
+        assert result.exit_code > 0
+
+    def test_ssl_connection_key_without_cert_fails(
+        self,
+        cli_runner: CliRunner,
+        sqlite_database: "os.PathLike[t.Any]",
+        mysql_database: Database,
+        mysql_credentials: MySQLCredentials,
+        mysql_ssl_certs: t.Optional["MySQLSSLCerts"],
+    ) -> None:
+        if mysql_ssl_certs is None:
+            pytest.skip("SSL certs not available for this environment")
+        result: Result = cli_runner.invoke(
+            mysql2sqlite,
+            [
+                "-f",
+                str(sqlite_database),
+                "-d",
+                mysql_credentials.database,
+                "-u",
+                mysql_credentials.user,
+                "--mysql-password",
+                mysql_credentials.password,
+                "-h",
+                mysql_credentials.host,
+                "-P",
+                str(mysql_credentials.port),
+                "--mysql-ssl-ca",
+                str(mysql_ssl_certs.ca),
+                "--mysql-ssl-key",
+                str(mysql_ssl_certs.client_key),
+            ],
+        )
+        assert result.exit_code > 0

--- a/tests/unit/test_cli_error_paths.py
+++ b/tests/unit/test_cli_error_paths.py
@@ -208,3 +208,67 @@ class TestCliErrorPaths:
         assert captured_kwargs["mysql_ssl_cert"] is None
         assert captured_kwargs["mysql_ssl_key"] is None
         assert captured_kwargs["mysql_ssl_disabled"] is False
+
+    def test_skip_ssl_with_ssl_options_rejected(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+        """--skip-ssl and --mysql-ssl-* options are mutually exclusive."""
+        monkeypatch.setattr("mysql_to_sqlite3.cli.mysql_supported_character_sets", _fake_supported_charsets)
+        monkeypatch.setattr("mysql_to_sqlite3.cli.MySQLtoSQLite", _FakeConverter)
+
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_text("fake")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            mysql2sqlite,
+            [
+                "-f", "out.sqlite3",
+                "-d", "db",
+                "-u", "user",
+                "--skip-ssl",
+                "--mysql-ssl-ca", str(ca_file),
+            ],
+        )
+        assert result.exit_code > 0
+        assert "mutually exclusive" in result.output
+
+    def test_ssl_cert_without_key_rejected(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+        """--mysql-ssl-cert without --mysql-ssl-key should be rejected."""
+        monkeypatch.setattr("mysql_to_sqlite3.cli.mysql_supported_character_sets", _fake_supported_charsets)
+        monkeypatch.setattr("mysql_to_sqlite3.cli.MySQLtoSQLite", _FakeConverter)
+
+        cert_file = tmp_path / "client-cert.pem"
+        cert_file.write_text("fake")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            mysql2sqlite,
+            [
+                "-f", "out.sqlite3",
+                "-d", "db",
+                "-u", "user",
+                "--mysql-ssl-cert", str(cert_file),
+            ],
+        )
+        assert result.exit_code > 0
+        assert "must be provided together" in result.output
+
+    def test_ssl_key_without_cert_rejected(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+        """--mysql-ssl-key without --mysql-ssl-cert should be rejected."""
+        monkeypatch.setattr("mysql_to_sqlite3.cli.mysql_supported_character_sets", _fake_supported_charsets)
+        monkeypatch.setattr("mysql_to_sqlite3.cli.MySQLtoSQLite", _FakeConverter)
+
+        key_file = tmp_path / "client-key.pem"
+        key_file.write_text("fake")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            mysql2sqlite,
+            [
+                "-f", "out.sqlite3",
+                "-d", "db",
+                "-u", "user",
+                "--mysql-ssl-key", str(key_file),
+            ],
+        )
+        assert result.exit_code > 0
+        assert "must be provided together" in result.output

--- a/tests/unit/test_cli_error_paths.py
+++ b/tests/unit/test_cli_error_paths.py
@@ -85,6 +85,9 @@ class TestCliErrorPaths:
             "mysql_port": 3306,
             "mysql_charset": "utf8mb4",
             "mysql_collation": None,
+            "mysql_ssl_ca": None,
+            "mysql_ssl_cert": None,
+            "mysql_ssl_key": None,
             "skip_ssl": False,
             "chunk": 200000,
             "log_file": None,
@@ -129,6 +132,9 @@ class TestCliErrorPaths:
             "mysql_port": 3306,
             "mysql_charset": "utf8mb4",
             "mysql_collation": None,
+            "mysql_ssl_ca": None,
+            "mysql_ssl_cert": None,
+            "mysql_ssl_key": None,
             "skip_ssl": False,
             "chunk": 200000,
             "log_file": None,
@@ -140,3 +146,65 @@ class TestCliErrorPaths:
         }
         with pytest.raises(RuntimeError):
             mysql2sqlite.callback(**kwargs)
+
+    def test_ssl_options_passed_to_converter(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+        """SSL options from CLI should be forwarded to the MySQLtoSQLite constructor."""
+        captured_kwargs = {}
+
+        class CapturingConverter:
+            def __init__(self, **kwargs):
+                captured_kwargs.update(kwargs)
+
+            def transfer(self):
+                pass
+
+        monkeypatch.setattr("mysql_to_sqlite3.cli.mysql_supported_character_sets", _fake_supported_charsets)
+        monkeypatch.setattr("mysql_to_sqlite3.cli.MySQLtoSQLite", CapturingConverter)
+
+        ca_file = tmp_path / "ca.pem"
+        cert_file = tmp_path / "client-cert.pem"
+        key_file = tmp_path / "client-key.pem"
+        for f in (ca_file, cert_file, key_file):
+            f.write_text("fake")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            mysql2sqlite,
+            [
+                "-f", "out.sqlite3",
+                "-d", "db",
+                "-u", "user",
+                "--mysql-ssl-ca", str(ca_file),
+                "--mysql-ssl-cert", str(cert_file),
+                "--mysql-ssl-key", str(key_file),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert captured_kwargs["mysql_ssl_ca"] == str(ca_file)
+        assert captured_kwargs["mysql_ssl_cert"] == str(cert_file)
+        assert captured_kwargs["mysql_ssl_key"] == str(key_file)
+
+    def test_ssl_options_default_to_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SSL options should default to None when not provided."""
+        captured_kwargs = {}
+
+        class CapturingConverter:
+            def __init__(self, **kwargs):
+                captured_kwargs.update(kwargs)
+
+            def transfer(self):
+                pass
+
+        monkeypatch.setattr("mysql_to_sqlite3.cli.mysql_supported_character_sets", _fake_supported_charsets)
+        monkeypatch.setattr("mysql_to_sqlite3.cli.MySQLtoSQLite", CapturingConverter)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            mysql2sqlite,
+            ["-f", "out.sqlite3", "-d", "db", "-u", "user"],
+        )
+        assert result.exit_code == 0, result.output
+        assert captured_kwargs["mysql_ssl_ca"] is None
+        assert captured_kwargs["mysql_ssl_cert"] is None
+        assert captured_kwargs["mysql_ssl_key"] is None
+        assert captured_kwargs["mysql_ssl_disabled"] is False

--- a/tests/unit/test_transporter.py
+++ b/tests/unit/test_transporter.py
@@ -1061,3 +1061,49 @@ class TestSSLOptions:
         assert connect_kwargs["ssl_ca"] is None
         assert connect_kwargs["ssl_cert"] is None
         assert connect_kwargs["ssl_key"] is None
+
+    def test_ssl_disabled_with_ssl_options_raises(
+        self,
+        sqlite_database: "os.PathLike[t.Any]",
+        mysql_credentials: MySQLCredentials,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """SSL disabled combined with SSL cert options should raise ValueError."""
+        with pytest.raises(ValueError, match="Cannot use SSL certificate options when SSL is disabled"):
+            self._make_instance(
+                monkeypatch,
+                sqlite_database,
+                mysql_credentials,
+                mysql_ssl_ca="/path/to/ca.pem",
+                mysql_ssl_disabled=True,
+            )
+
+    def test_ssl_cert_without_key_raises(
+        self,
+        sqlite_database: "os.PathLike[t.Any]",
+        mysql_credentials: MySQLCredentials,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Providing ssl_cert without ssl_key should raise ValueError."""
+        with pytest.raises(ValueError, match="mysql_ssl_cert and mysql_ssl_key must be provided together"):
+            self._make_instance(
+                monkeypatch,
+                sqlite_database,
+                mysql_credentials,
+                mysql_ssl_cert="/path/to/client-cert.pem",
+            )
+
+    def test_ssl_key_without_cert_raises(
+        self,
+        sqlite_database: "os.PathLike[t.Any]",
+        mysql_credentials: MySQLCredentials,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Providing ssl_key without ssl_cert should raise ValueError."""
+        with pytest.raises(ValueError, match="mysql_ssl_cert and mysql_ssl_key must be provided together"):
+            self._make_instance(
+                monkeypatch,
+                sqlite_database,
+                mysql_credentials,
+                mysql_ssl_key="/path/to/client-key.pem",
+            )

--- a/tests/unit/test_transporter.py
+++ b/tests/unit/test_transporter.py
@@ -897,3 +897,167 @@ def test_transfer_coerce_row_fallback_non_subscriptable() -> None:
     # The info call is like: ("%s%sTransferring table %s", prefix1, prefix2, table_name)
     called_with_123 = any(call.args and call.args[-1] == "123" for call in instance._logger.info.call_args_list)
     assert called_with_123
+
+
+class TestSSLOptions:
+    """Tests for MySQL SSL certificate options."""
+
+    def _make_instance(self, monkeypatch, sqlite_database, mysql_credentials, **extra_kwargs):
+        """Create a MySQLtoSQLite instance with fake MySQL connection."""
+        from mysql_to_sqlite3 import transporter as transporter_module
+
+        connect_kwargs = {}
+
+        class FakeMySQLConnection:
+            def __init__(self):
+                self.database = None
+
+            def is_connected(self):
+                return True
+
+            def cursor(self, *args, **kwargs):
+                return MagicMock()
+
+            def get_server_version(self):
+                return (8, 0, 21)
+
+            def reconnect(self):
+                return None
+
+        fake_conn = FakeMySQLConnection()
+
+        fake_charset = SimpleNamespace(
+            get_default_collation=lambda charset: ("utf8mb4_unicode_ci", None),
+            get_supported=lambda: ("utf8mb4",),
+        )
+
+        def fake_connect(**kwargs):
+            connect_kwargs.update(kwargs)
+            return fake_conn
+
+        monkeypatch.setattr("mysql_to_sqlite3.transporter.CharacterSet", lambda: fake_charset)
+        monkeypatch.setattr("mysql_to_sqlite3.transporter.mysql.connector.connect", fake_connect)
+        monkeypatch.setattr(MySQLtoSQLite, "_setup_logger", MagicMock(return_value=MagicMock()))
+
+        original_isinstance = builtins.isinstance
+
+        def fake_isinstance(obj, classinfo):
+            if obj is fake_conn and classinfo is transporter_module.MySQLConnectionAbstract:
+                return True
+            return original_isinstance(obj, classinfo)
+
+        monkeypatch.setattr("mysql_to_sqlite3.transporter.isinstance", fake_isinstance, raising=False)
+
+        kwargs = dict(
+            sqlite_file=sqlite_database,
+            mysql_user=mysql_credentials.user,
+            mysql_password=mysql_credentials.password,
+            mysql_host=mysql_credentials.host,
+            mysql_port=mysql_credentials.port,
+            mysql_database=mysql_credentials.database,
+        )
+        kwargs.update(extra_kwargs)
+        instance = MySQLtoSQLite(**kwargs)
+        return instance, connect_kwargs
+
+    def test_ssl_params_passed_to_mysql_connector(
+        self,
+        sqlite_database: "os.PathLike[t.Any]",
+        mysql_credentials: MySQLCredentials,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """SSL certificate paths should be forwarded to mysql.connector.connect."""
+        instance, connect_kwargs = self._make_instance(
+            monkeypatch,
+            sqlite_database,
+            mysql_credentials,
+            mysql_ssl_ca="/path/to/ca.pem",
+            mysql_ssl_cert="/path/to/client-cert.pem",
+            mysql_ssl_key="/path/to/client-key.pem",
+        )
+        assert instance._mysql_ssl_ca == "/path/to/ca.pem"
+        assert instance._mysql_ssl_cert == "/path/to/client-cert.pem"
+        assert instance._mysql_ssl_key == "/path/to/client-key.pem"
+        assert connect_kwargs["ssl_ca"] == "/path/to/ca.pem"
+        assert connect_kwargs["ssl_cert"] == "/path/to/client-cert.pem"
+        assert connect_kwargs["ssl_key"] == "/path/to/client-key.pem"
+
+    def test_ssl_params_default_to_none(
+        self,
+        sqlite_database: "os.PathLike[t.Any]",
+        mysql_credentials: MySQLCredentials,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """SSL certificate paths should default to None when not provided."""
+        instance, connect_kwargs = self._make_instance(
+            monkeypatch,
+            sqlite_database,
+            mysql_credentials,
+        )
+        assert instance._mysql_ssl_ca is None
+        assert instance._mysql_ssl_cert is None
+        assert instance._mysql_ssl_key is None
+        assert connect_kwargs["ssl_ca"] is None
+        assert connect_kwargs["ssl_cert"] is None
+        assert connect_kwargs["ssl_key"] is None
+
+    def test_ssl_ca_only(
+        self,
+        sqlite_database: "os.PathLike[t.Any]",
+        mysql_credentials: MySQLCredentials,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Only ssl_ca can be provided without cert and key."""
+        instance, connect_kwargs = self._make_instance(
+            monkeypatch,
+            sqlite_database,
+            mysql_credentials,
+            mysql_ssl_ca="/path/to/ca.pem",
+        )
+        assert instance._mysql_ssl_ca == "/path/to/ca.pem"
+        assert instance._mysql_ssl_cert is None
+        assert instance._mysql_ssl_key is None
+        assert connect_kwargs["ssl_ca"] == "/path/to/ca.pem"
+
+    def test_ssl_cert_and_key_without_ca(
+        self,
+        sqlite_database: "os.PathLike[t.Any]",
+        mysql_credentials: MySQLCredentials,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """cert and key can be provided without a CA certificate."""
+        instance, connect_kwargs = self._make_instance(
+            monkeypatch,
+            sqlite_database,
+            mysql_credentials,
+            mysql_ssl_cert="/path/to/client-cert.pem",
+            mysql_ssl_key="/path/to/client-key.pem",
+        )
+        assert instance._mysql_ssl_ca is None
+        assert instance._mysql_ssl_cert == "/path/to/client-cert.pem"
+        assert instance._mysql_ssl_key == "/path/to/client-key.pem"
+        assert connect_kwargs["ssl_ca"] is None
+        assert connect_kwargs["ssl_cert"] == "/path/to/client-cert.pem"
+        assert connect_kwargs["ssl_key"] == "/path/to/client-key.pem"
+
+    def test_ssl_empty_strings_treated_as_none(
+        self,
+        sqlite_database: "os.PathLike[t.Any]",
+        mysql_credentials: MySQLCredentials,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Empty string SSL paths should be normalized to None."""
+        instance, connect_kwargs = self._make_instance(
+            monkeypatch,
+            sqlite_database,
+            mysql_credentials,
+            mysql_ssl_ca="",
+            mysql_ssl_cert="",
+            mysql_ssl_key="",
+        )
+        assert instance._mysql_ssl_ca is None
+        assert instance._mysql_ssl_cert is None
+        assert instance._mysql_ssl_key is None
+        assert connect_kwargs["ssl_ca"] is None
+        assert connect_kwargs["ssl_cert"] is None
+        assert connect_kwargs["ssl_key"] is None

--- a/tests/unit/test_transporter.py
+++ b/tests/unit/test_transporter.py
@@ -981,6 +981,7 @@ class TestSSLOptions:
         assert connect_kwargs["ssl_ca"] == "/path/to/ca.pem"
         assert connect_kwargs["ssl_cert"] == "/path/to/client-cert.pem"
         assert connect_kwargs["ssl_key"] == "/path/to/client-key.pem"
+        assert connect_kwargs["ssl_verify_cert"] is True
 
     def test_ssl_params_default_to_none(
         self,
@@ -1000,6 +1001,7 @@ class TestSSLOptions:
         assert connect_kwargs["ssl_ca"] is None
         assert connect_kwargs["ssl_cert"] is None
         assert connect_kwargs["ssl_key"] is None
+        assert connect_kwargs["ssl_verify_cert"] is False
 
     def test_ssl_ca_only(
         self,
@@ -1018,6 +1020,7 @@ class TestSSLOptions:
         assert instance._mysql_ssl_cert is None
         assert instance._mysql_ssl_key is None
         assert connect_kwargs["ssl_ca"] == "/path/to/ca.pem"
+        assert connect_kwargs["ssl_verify_cert"] is True
 
     def test_ssl_cert_and_key_without_ca(
         self,
@@ -1039,6 +1042,7 @@ class TestSSLOptions:
         assert connect_kwargs["ssl_ca"] is None
         assert connect_kwargs["ssl_cert"] == "/path/to/client-cert.pem"
         assert connect_kwargs["ssl_key"] == "/path/to/client-key.pem"
+        assert connect_kwargs["ssl_verify_cert"] is False
 
     def test_ssl_empty_strings_treated_as_none(
         self,


### PR DESCRIPTION
## Summary

- Add `--mysql-ssl-ca`, `--mysql-ssl-cert`, and `--mysql-ssl-key` CLI options for connecting to MySQL databases that require secure transport (`--require_secure_transport=ON`)
- Thread SSL params through types, transporter, and `mysql.connector.connect()`
- Add unit and functional tests for SSL connections, including Docker-based tests that extract auto-generated certs from MySQL 8.0+ containers and gracefully skip on older MySQL/MariaDB versions that don't provide certs

---

### Supersedes

* #77