### PR TITLE
:memo: improve project documentation and user guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,8 +16,8 @@ CLI defined in `cli.py`. The transfer pipeline:
 
 ## 2. Key Modules & Responsibilities
 
-- `src/mysql_to_sqlite3/cli.py`: Click command. Central place to add new user-facing options (update docs + README +
-  `docs/index.rst` if changed).
+- `src/mysql_to_sqlite3/cli.py`: Click command. Central place to add new user-facing options (update `README.md`,
+  `docs/README.rst`, and `docs/index.rst` if changed).
 - `src/mysql_to_sqlite3/transporter.py`: Core transfer logic, schema introspection, type/default translation, batching,
   logging, reconnection handling.
 - `sqlite_utils.py` / `mysql_utils.py`: Helpers for charset/collation sets, adapting/encoding values and SQLite
@@ -25,6 +25,8 @@ CLI defined in `cli.py`. The transfer pipeline:
 - `types.py`: Typed parameter & attribute Protocols / TypedDict-like structures for constructor kwargs (mypy relies on
   this; keep hints exhaustive).
 - `debug_info.py`: Version table printed with `--version` (tabulated output).
+- `skills/mysql-to-sqlite3/SKILL.md`: User-facing migration-assistant skill. Keep it about planning and running
+  transfers, not repository maintenance.
 
 ## 3. Patterns & Conventions
 
@@ -74,7 +76,7 @@ CLI defined in `cli.py`. The transfer pipeline:
 
 1. Add `@click.option` in `cli.py` (keep mutually exclusive logic consistent).
 2. Thread parameter through `MySQLtoSQLite` constructor (update typing + tests).
-3. Update docs: `README.md` + `docs/index.rst` + optionally changelog.
+3. Update docs: `README.md`, `docs/README.rst`, `docs/index.rst`, and optionally changelog.
 4. Add at least one unit test exercising the new behavior / validation.
 
 ## 8. Error Handling Philosophy
@@ -95,7 +97,7 @@ CLI defined in `cli.py`. The transfer pipeline:
 
 ## 11. Examples
 
-- Chunked transfer: `mysql2sqlite -f out.db -d db -u user -p -c 50000` (efficient large table copy).
+- Chunked transfer: `mysql2sqlite -f out.db -d db -u user -p -c 50000` (efficient large table transfer).
 - Subset tables (no FKs): `mysql2sqlite -f out.db -d db -u user -t users orders`.
 
 ## 12. PR Expectations

--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,9 @@ dmypy.json
 # Potential leftovers
 tests/db_credentials.json
 log.txt
+
+# AI related
+.junie/
+
+# VSCode
+.history

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,13 +19,14 @@ with `python -m build` or `hatch build`.
 ## Coding Style & Naming Conventions
 
 Format code with `black` (120-char lines) and keep imports sorted via `isort --profile black`. Prefer descriptive
-snake_case for functions and variables, CamelCase for classes, and suffix CLI command callbacks with `_cmd`. Maintain
-full type hints; the package is shipped as typed and mypy checks run with `python_version=3.9`. Avoid introducing new
-modules without tests.
+snake_case for functions and variables, and CamelCase for classes. For Click command callbacks, follow the repository's
+existing convention: reuse the established top-level `cli` entrypoint or a single consistent descriptive name across
+commands. Maintain full type hints; the package is shipped as typed and mypy checks run with `python_version=3.9`. Avoid
+introducing new modules without tests.
 
 ## Testing Guidelines
 
-Write `pytest` unit tests using alongside the feature under `tests/unit/` and integration cases under `tests/func/`.
+Write `pytest` unit tests for the feature under `tests/unit/` and integration tests under `tests/func/`.
 Name test files `test_<feature>.py` and mark long-running scenarios with existing pytest markers (
 `@pytest.mark.transfer`, etc.). Ensure the functional suite can target the dockerised MySQL instance configured in
 `tests/db_credentials.json`; set `LEGACY_DB` when validating backward compatibility. Keep coverage trending upward;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,8 @@ introducing new modules without tests.
 ## Testing Guidelines
 
 Write `pytest` unit tests for the feature under `tests/unit/` and integration tests under `tests/func/`.
-Name test files `test_<feature>.py` and mark long-running scenarios with existing pytest markers (
-`@pytest.mark.transfer`, etc.). Ensure the functional suite can target the dockerised MySQL instance configured in
+Name test files `test_<feature>.py`. Mark long-running scenarios with existing pytest markers such as
+`@pytest.mark.transfer`. Ensure the functional suite can target the dockerised MySQL instance configured in
 `tests/db_credentials.json`; set `LEGACY_DB` when validating backward compatibility. Keep coverage trending upward;
 update `coverage.xml` only through the tooling.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+The core package lives in `src/mysql_to_sqlite3/` with CLI entry points (`cli.py`), transport logic, and utility
+modules. Types and typing stubs ship via `types.py` and `py.typed`. Tests are split between `tests/unit/` for isolated
+logic and `tests/func/` for database-backed flows; shared factories and fixtures sit in `tests/factories.py` and
+`tests/conftest.py`. Sphinx docs reside in `docs/`, while built artifacts land in `dist/` and coverage data in
+`htmlcov/` and `coverage.xml`. The optional user-facing agent skill lives in `skills/mysql-to-sqlite3/SKILL.md`; keep it
+focused on migration help rather than contributor workflow.
+
+## Build, Test, and Development Commands
+
+Use `python -m venv env` and `pip install -e .` plus `pip install -r requirements_dev.txt` for a dev environment. Run
+`pytest -v --cov=src/mysql_to_sqlite3` for targeted testing, or `tox` to execute the full matrix across Python versions.
+`tox -e linters` runs formatters and static analysis (`black`, `isort`, `flake8`, `mypy`, `bandit`). Build distributions
+with `python -m build` or `hatch build`.
+
+## Coding Style & Naming Conventions
+
+Format code with `black` (120-char lines) and keep imports sorted via `isort --profile black`. Prefer descriptive
+snake_case for functions and variables, CamelCase for classes, and suffix CLI command callbacks with `_cmd`. Maintain
+full type hints; the package is shipped as typed and mypy checks run with `python_version=3.9`. Avoid introducing new
+modules without tests.
+
+## Testing Guidelines
+
+Write `pytest` unit tests using alongside the feature under `tests/unit/` and integration cases under `tests/func/`.
+Name test files `test_<feature>.py` and mark long-running scenarios with existing pytest markers (
+`@pytest.mark.transfer`, etc.). Ensure the functional suite can target the dockerised MySQL instance configured in
+`tests/db_credentials.json`; set `LEGACY_DB` when validating backward compatibility. Keep coverage trending upward;
+update `coverage.xml` only through the tooling.
+
+## Commit & Pull Request Guidelines
+
+Follow the repository’s Gitmoji-inspired history (`:safety_vest:`, `:test_tube:`) for quick context, but prioritise
+clear subject lines under 72 characters. Larger changes should include a short body detailing impact and migrations.
+Reference related issues with `Fixes #123` and consolidate breaking work into focused commits. Pull requests must
+describe the change, call out manual test results, and attach CLI output or screenshots when UX is affected.
+
+## Database & Security Notes
+
+Never commit real credentials. Use ephemeral docker containers for MySQL/MariaDB testing and add new connection flags
+through the central `cli` options to keep behaviour consistent. Update `README.md`, `docs/README.rst`, and
+`docs/index.rst` whenever user-facing flags or caveats change, and note security-related fixes in `SECURITY.md`.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/mysql-to-sqlite3?logo=pypi&label=PyPI%20downloads)](https://pypistats.org/packages/mysql-to-sqlite3)
 [![Homebrew Formula Downloads](https://img.shields.io/homebrew/installs/dm/mysql-to-sqlite3?logo=homebrew&label=Homebrew%20downloads)](https://formulae.brew.sh/formula/mysql-to-sqlite3)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/mysql-to-sqlite3?logo=python)](https://pypi.org/project/mysql-to-sqlite3/)
-[![MySQL Support](https://img.shields.io/static/v1?logo=mysql&label=MySQL&message=5.5+|+5.6+|+5.7+|+8.0+|+8.4&color=2b5d80)](https://img.shields.io/static/v1?label=MySQL&message=5.5+|+5.6+|+5.7+|+8.0+|+8.4&color=2b5d80)
-[![MariaDB Support](https://img.shields.io/static/v1?logo=mariadb&label=MariaDB&message=5.5+|+10.0+|+10.6+|+10.11+|+11.4+|+11.6+|+11.8&color=C0765A)](https://img.shields.io/static/v1?label=MariaDB&message=5.5+|+10.0+|+10.6+|+10.11+|+11.4+|+11.6+|+11.8&color=C0765A)
+[![MySQL Support](https://img.shields.io/static/v1?logo=mysql&label=MySQL&message=5.5%7C5.6%7C5.7%7C8.0%7C8.4&color=2b5d80)](https://github.com/techouse/mysql-to-sqlite3/actions/workflows/test.yml)
+[![MariaDB Support](https://img.shields.io/static/v1?logo=mariadb&label=MariaDB&message=5.5%7C10.0%7C10.6%7C10.11%7C11.4%7C11.8&color=C0765A)](https://github.com/techouse/mysql-to-sqlite3/actions/workflows/test.yml)
 [![GitHub license](https://img.shields.io/github/license/techouse/mysql-to-sqlite3)](https://github.com/techouse/mysql-to-sqlite3/blob/master/LICENSE)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?logo=contributorcovenant)](CODE-OF-CONDUCT.md)
-[![PyPI - Format](https://img.shields.io/pypi/format/mysql-to-sqlite3?logo=python)](https://pypi.org/project/sqlite3-to-mysql/)
+[![PyPI - Format](https://img.shields.io/pypi/format/mysql-to-sqlite3?logo=python)](https://pypi.org/project/mysql-to-sqlite3/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?logo=python)](https://github.com/ambv/black)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/64aae8e9599746d58d277852b35cc2bd)](https://www.codacy.com/manual/techouse/mysql-to-sqlite3?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=techouse/mysql-to-sqlite3&amp;utm_campaign=Badge_Grade)
 [![Test Status](https://github.com/techouse/mysql-to-sqlite3/actions/workflows/test.yml/badge.svg)](https://github.com/techouse/mysql-to-sqlite3/actions/workflows/test.yml)
@@ -18,111 +18,229 @@
 
 # MySQL to SQLite3
 
-#### A simple Python tool to transfer data from MySQL to SQLite 3.
+A Python CLI for transferring MySQL or MariaDB schema and data to a SQLite 3 database file.
 
-### How to run
+`mysql2sqlite` reads the source schema from MySQL/MariaDB, creates equivalent SQLite tables, indexes, views, and
+foreign keys where possible, then transfers table data into the SQLite file.
+
+## Prerequisites
+
+- Python 3.9 or newer, unless you use the Docker image.
+- A reachable MySQL or MariaDB server.
+- A MySQL user that can read the source database and its metadata in `information_schema`.
+- A writable destination path for the SQLite database file.
+
+The project CI tests MySQL 5.5, 5.6, 5.7, 8.0, and 8.4, plus MariaDB 5.5, 10.0, 10.6, 10.11, 11.4, and 11.8.
+Very old server versions are more likely to differ in type, default-value, authentication, or metadata behavior.
+
+## Installation
+
+Install from PyPI:
 
 ```bash
 pip install mysql-to-sqlite3
 mysql2sqlite --help
 ```
 
-### Usage
-
-```
-Usage: mysql2sqlite [OPTIONS]
-
-Options:
-  -f, --sqlite-file PATH          SQLite3 database file  [required]
-  -d, --mysql-database TEXT       MySQL database name  [required]
-  -u, --mysql-user TEXT           MySQL user  [required]
-  -p, --prompt-mysql-password     Prompt for MySQL password
-  --mysql-password TEXT           MySQL password
-  -t, --mysql-tables TUPLE        Transfer only these specific tables (space
-                                  separated table names). Implies --without-
-                                  foreign-keys which inhibits the transfer of
-                                  foreign keys. Can not be used together with
-                                  --exclude-mysql-tables.
-  -e, --exclude-mysql-tables TUPLE
-                                  Transfer all tables except these specific
-                                  tables (space separated table names).
-                                  Implies --without-foreign-keys which
-                                  inhibits the transfer of foreign keys. Can
-                                  not be used together with --mysql-tables.
-  -T, --mysql-views-as-tables     Materialize MySQL VIEWs as SQLite tables
-                                  (legacy behavior).
-  -L, --limit-rows INTEGER        Transfer only a limited number of rows from
-                                  each table.
-  -C, --collation [BINARY|NOCASE|RTRIM]
-                                  Create datatypes of TEXT affinity using a
-                                  specified collation sequence.  [default:
-                                  BINARY]
-  -K, --prefix-indices            Prefix indices with their corresponding
-                                  tables. This ensures that their names remain
-                                  unique across the SQLite database.
-  -X, --without-foreign-keys      Do not transfer foreign keys.
-  -Z, --without-tables            Do not transfer tables, data only.
-  -W, --without-data              Do not transfer table data, DDL only.
-  -M, --strict                    Create SQLite STRICT tables when supported.
-  -h, --mysql-host TEXT           MySQL host. Defaults to localhost.
-  -P, --mysql-port INTEGER        MySQL port. Defaults to 3306.
-  --mysql-charset TEXT            MySQL database and table character set
-                                  [default: utf8mb4]
-  --mysql-collation TEXT          MySQL database and table collation
-  --mysql-ssl-ca PATH             Path to SSL CA certificate file.
-  --mysql-ssl-cert PATH           Path to SSL certificate file.
-                                  Must be provided together with
-                                  --mysql-ssl-key.
-  --mysql-ssl-key PATH            Path to SSL key file.
-                                  Must be provided together with
-                                  --mysql-ssl-cert.
-  -S, --skip-ssl                  Disable MySQL connection encryption.
-                                  Cannot be used with --mysql-ssl-* options.
-  -c, --chunk INTEGER             Chunk reading/writing SQL records
-  -l, --log-file PATH             Log file
-  --json-as-text                  Transfer JSON columns as TEXT.
-  -V, --vacuum                    Use the VACUUM command to rebuild the SQLite
-                                  database file, repacking it into a minimal
-                                  amount of disk space
-  --use-buffered-cursors          Use MySQLCursorBuffered for reading the
-                                  MySQL database. This can be useful in
-                                  situations where multiple queries, with
-                                  small result sets, need to be combined or
-                                  computed with each other.
-  -q, --quiet                     Quiet. Display only errors.
-  --debug                         Debug mode. Will throw exceptions.
-  --version                       Show the version and exit.
-  --help                          Show this message and exit.
-```
-
-#### Docker
-
-If you don't want to install the tool on your system, you can use the Docker image instead.
-
-```bash
-docker run -it \
-    --workdir $(pwd) \
-    --volume $(pwd):$(pwd) \
-    --rm ghcr.io/techouse/mysql-to-sqlite3:latest \
-    --sqlite-file baz.db \
-    --mysql-user foo \
-    --mysql-password bar \
-    --mysql-database baz \
-    --mysql-host host.docker.internal
-```
-
-This will mount your host current working directory (pwd) inside the Docker container as the current working directory.
-Any files Docker would write to the current working directory are written to the host directory where you did docker
-run. Note that you have to also use a
-[special hostname](https://docs.docker.com/desktop/networking/#use-cases-and-workarounds-for-all-platforms)
-`host.docker.internal`
-to access your host machine from inside the Docker container.
-
-#### Homebrew
-
-If you're on macOS, you can install the tool using [Homebrew](https://brew.sh/).
+On macOS, you can also install with Homebrew:
 
 ```bash
 brew install mysql-to-sqlite3
 mysql2sqlite --help
 ```
+
+Or run the published Docker image:
+
+```bash
+docker run --rm ghcr.io/techouse/mysql-to-sqlite3:latest --help
+```
+
+## Quick start
+
+Use `-p` / `--prompt-mysql-password` for interactive password entry. This avoids putting the password in shell history
+or process listings.
+
+```bash
+mysql2sqlite \
+    --sqlite-file ./app.sqlite3 \
+    --mysql-database app_db \
+    --mysql-user app_user \
+    --prompt-mysql-password \
+    --mysql-host 127.0.0.1 \
+    --mysql-port 3306
+```
+
+Short options are equivalent:
+
+```bash
+mysql2sqlite -f ./app.sqlite3 -d app_db -u app_user -p -h 127.0.0.1 -P 3306
+```
+
+For automation, `--mysql-password` is available, but prefer a secret manager or environment-expanded value rather than
+typing the password directly into your shell history.
+
+## Common recipes
+
+### Run with Docker
+
+Use `host.docker.internal` when the MySQL server is running on the host machine and the Docker container needs to reach
+it.
+
+```bash
+docker run -it \
+    --rm \
+    --workdir "$PWD" \
+    --volume "$PWD:$PWD" \
+    ghcr.io/techouse/mysql-to-sqlite3:latest \
+    -f ./app.sqlite3 \
+    -d app_db \
+    -u app_user \
+    -p \
+    -h host.docker.internal
+```
+
+Files written inside the mounted working directory are written back to the host directory.
+
+### Transfer schema only
+
+Create the SQLite tables, indexes, views, and foreign keys without transferring table rows.
+
+```bash
+mysql2sqlite -f ./schema.sqlite3 -d app_db -u app_user -p --without-data
+```
+
+### Transfer data into an existing SQLite schema
+
+`--without-tables` skips DDL creation and only inserts data. The SQLite tables must already exist.
+
+```bash
+mysql2sqlite -f ./app.sqlite3 -d app_db -u app_user -p --without-tables
+```
+
+A common two-step flow is:
+
+```bash
+mysql2sqlite -f ./app.sqlite3 -d app_db -u app_user -p --without-data
+mysql2sqlite -f ./app.sqlite3 -d app_db -u app_user -p --without-tables
+```
+
+### Transfer only some tables
+
+Table names are space-separated and are consumed until the next CLI option.
+
+```bash
+mysql2sqlite -f ./subset.sqlite3 -d app_db -u app_user -p --mysql-tables users orders invoices
+```
+
+Transfer everything except selected tables:
+
+```bash
+mysql2sqlite -f ./subset.sqlite3 -d app_db -u app_user -p --exclude-mysql-tables audit_log temp_imports
+```
+
+Selecting or excluding tables disables foreign key transfer because the referenced tables may not be present.
+
+### Sample rows from every table
+
+Transfer at most 100 rows from each table:
+
+```bash
+mysql2sqlite -f ./sample.sqlite3 -d app_db -u app_user -p --limit-rows 100
+```
+
+### Tune large transfers
+
+The CLI fetches and writes rows in batches by default. Use `--chunk` to tune the batch size. `--vacuum` repacks the
+SQLite file after the transfer finishes.
+
+```bash
+mysql2sqlite -f ./app.sqlite3 -d app_db -u app_user -p --chunk 50000 --vacuum
+```
+
+### Use SSL certificates
+
+Verify the server certificate with a CA file:
+
+```bash
+mysql2sqlite -f ./app.sqlite3 -d app_db -u app_user -p --mysql-ssl-ca /path/to/ca.pem
+```
+
+Use a client certificate and key:
+
+```bash
+mysql2sqlite \
+    -f ./app.sqlite3 \
+    -d app_db \
+    -u app_user \
+    -p \
+    --mysql-ssl-ca /path/to/ca.pem \
+    --mysql-ssl-cert /path/to/client-cert.pem \
+    --mysql-ssl-key /path/to/client-key.pem
+```
+
+Use `--skip-ssl` only when you explicitly need to disable MySQL connection encryption.
+
+## Options at a glance
+
+| Option | Purpose |
+| --- | --- |
+| `-f`, `--sqlite-file PATH` | Destination SQLite database file. Required. |
+| `-d`, `--mysql-database TEXT` | Source MySQL/MariaDB database name. Required. |
+| `-u`, `--mysql-user TEXT` | MySQL/MariaDB user. Required. |
+| `-p`, `--prompt-mysql-password` | Prompt for the MySQL password. Preferred for interactive use. |
+| `--mysql-password TEXT` | Provide the MySQL password directly. Useful for automation, but handle carefully. |
+| `-h`, `--mysql-host TEXT` | MySQL host. Defaults to `localhost`. |
+| `-P`, `--mysql-port INTEGER` | MySQL port. Defaults to `3306`. |
+| `-t`, `--mysql-tables TUPLE` | Transfer only the listed tables. Implies no foreign key transfer. |
+| `-e`, `--exclude-mysql-tables TUPLE` | Transfer every table except the listed tables. Implies no foreign key transfer. |
+| `-T`, `--mysql-views-as-tables` | Materialize MySQL views as SQLite tables instead of creating SQLite views. |
+| `-L`, `--limit-rows INTEGER` | Transfer at most this many rows from each table. `0` means no limit. |
+| `-C`, `--collation [BINARY\|NOCASE\|RTRIM]` | Add a SQLite collation to text-affinity columns. Defaults to `BINARY`. |
+| `-K`, `--prefix-indices` | Prefix SQLite index names with their table names. |
+| `-X`, `--without-foreign-keys` | Do not create foreign keys in the SQLite schema. |
+| `-Z`, `--without-tables` | Skip table/view creation and transfer data only. |
+| `-W`, `--without-data` | Create schema only and skip table data. |
+| `-M`, `--strict` | Create SQLite STRICT tables when the local SQLite version supports them. |
+| `--mysql-charset TEXT` | MySQL connection character set. Defaults to `utf8mb4`. |
+| `--mysql-collation TEXT` | MySQL connection collation. Must belong to the selected charset. |
+| `--mysql-ssl-ca PATH` | Path to an SSL CA certificate file. |
+| `--mysql-ssl-cert PATH` | Path to an SSL client certificate file. Must be paired with `--mysql-ssl-key`. |
+| `--mysql-ssl-key PATH` | Path to an SSL client key file. Must be paired with `--mysql-ssl-cert`. |
+| `-S`, `--skip-ssl` | Disable MySQL connection encryption. Cannot be used with SSL certificate options. |
+| `-c`, `--chunk INTEGER` | Read and write SQL records in batches. Defaults to `200000`. |
+| `-l`, `--log-file PATH` | Write logs to a file. |
+| `--json-as-text` | Force MySQL/MariaDB JSON columns to SQLite `TEXT`. |
+| `-V`, `--vacuum` | Run SQLite `VACUUM` after transfer. |
+| `--use-buffered-cursors` | Use buffered MySQL cursors. |
+| `-q`, `--quiet` | Show only errors after the initial command banner. |
+| `--debug` | Re-raise exceptions for debugging instead of printing friendly errors. |
+| `--version` | Show environment and dependency versions. |
+| `--help` | Show CLI help. |
+
+## Combinations and caveats
+
+- `--mysql-tables` and `--exclude-mysql-tables` are mutually exclusive.
+- `--mysql-tables` or `--exclude-mysql-tables` automatically disables foreign key transfer.
+- `--without-tables` and `--without-data` cannot be used together because there would be nothing to do.
+- `--without-tables` requires the destination SQLite schema to already exist.
+- `--skip-ssl` cannot be combined with `--mysql-ssl-ca`, `--mysql-ssl-cert`, or `--mysql-ssl-key`.
+- `--mysql-ssl-cert` and `--mysql-ssl-key` must be provided together.
+- `--mysql-collation` must be valid for the selected `--mysql-charset`.
+- `--limit-rows` must be `0` or a positive integer. `0` means no limit.
+- `--strict` requires SQLite 3.37 or newer. If SQLite rejects a STRICT schema, rerun without `--strict`.
+- MySQL views become SQLite views by default. Use `--mysql-views-as-tables` for the older materialized-table behavior.
+
+## MySQL, MariaDB, and SQLite notes
+
+- MySQL and MariaDB are similar but not identical. Default expressions, generated defaults, authentication plugins, JSON
+  behavior, and metadata returned from `information_schema` can differ by server family and version.
+- Older legacy servers may not support newer column types such as native `JSON`.
+- MySQL/MariaDB `JSON` columns map to SQLite `JSON` only when this tool detects SQLite JSON1 support. Otherwise they
+  map to `TEXT`. Use `--json-as-text` to force `TEXT`.
+- `ENUM`, `SET`, unsupported spatial/network-style types, and unknown types fall back to `TEXT`.
+- MySQL `TIMESTAMP` columns are represented as SQLite `DATETIME`.
+- Unsigned integer types are converted to their signed SQLite-compatible type names.
+- Table names, column names, and index names are quoted for SQLite. Duplicate SQLite index names are made unique, and
+  `--prefix-indices` can make this behavior explicit.
+- After transfer, verify schema details that are important to your application, especially defaults, collations, JSON
+  columns, views, and foreign keys.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ foreign keys where possible, then transfers table data into the SQLite file.
 - A MySQL user that can read the source database and its metadata in `information_schema`.
 - A writable destination path for the SQLite database file.
 
-The project CI tests MySQL 5.5, 5.6, 5.7, 8.0, and 8.4, plus MariaDB 5.5, 10.0, 10.6, 10.11, 11.4, and 11.8.
-Very old server versions are more likely to differ in type, default-value, authentication, or metadata behavior.
+See the
+[GitHub Actions CI matrix](https://github.com/techouse/mysql-to-sqlite3/blob/master/.github/workflows/test.yml) for
+the current MySQL and MariaDB versions tested by the project. Very old server versions are more likely to differ in
+type, default-value, authentication, or metadata behavior.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ typing the password directly into your shell history.
 ### Run with Docker
 
 Use `host.docker.internal` when the MySQL server is running on the host machine and the Docker container needs to reach
-it.
+it. On Linux Docker Engine, add `--add-host=host.docker.internal:host-gateway` before the image name if
+`host.docker.internal` is not resolvable.
 
 ```bash
 docker run -it \
@@ -208,8 +209,8 @@ Use `--skip-ssl` only when you explicitly need to disable MySQL connection encry
 | `-Z`, `--without-tables` | Skip table/view creation and transfer data only. |
 | `-W`, `--without-data` | Create schema only and skip table data. |
 | `-M`, `--strict` | Create SQLite STRICT tables when the local SQLite version supports them. |
-| `--mysql-charset TEXT` | MySQL connection character set. Defaults to `utf8mb4`. |
-| `--mysql-collation TEXT` | MySQL connection collation. Must belong to the selected charset. |
+| `--mysql-charset TEXT` | MySQL database and table character set. Defaults to `utf8mb4`. |
+| `--mysql-collation TEXT` | MySQL database and table collation. Must belong to the selected charset. |
 | `--mysql-ssl-ca PATH` | Path to an SSL CA certificate file. |
 | `--mysql-ssl-cert PATH` | Path to an SSL client certificate file. Must be paired with `--mysql-ssl-key`. |
 | `--mysql-ssl-key PATH` | Path to an SSL client key file. Must be paired with `--mysql-ssl-cert`. |

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Use `--skip-ssl` only when you explicitly need to disable MySQL connection encry
 | `-X`, `--without-foreign-keys` | Do not create foreign keys in the SQLite schema. |
 | `-Z`, `--without-tables` | Skip table/view creation and transfer data only. |
 | `-W`, `--without-data` | Create schema only and skip table data. |
-| `-M`, `--strict` | Create SQLite STRICT tables when the local SQLite version supports them. |
+| `-M`, `--strict` | Request SQLite STRICT tables; older SQLite versions fall back to non-STRICT tables with a warning. |
 | `--mysql-charset TEXT` | MySQL database and table character set. Defaults to `utf8mb4`. |
 | `--mysql-collation TEXT` | MySQL database and table collation. Must belong to the selected charset. |
 | `--mysql-ssl-ca PATH` | Path to an SSL CA certificate file. |
@@ -237,7 +237,8 @@ Use `--skip-ssl` only when you explicitly need to disable MySQL connection encry
 - `--mysql-ssl-cert` and `--mysql-ssl-key` must be provided together.
 - `--mysql-collation` must be valid for the selected `--mysql-charset`.
 - `--limit-rows` must be `0` or a positive integer. `0` means no limit.
-- `--strict` requires SQLite 3.37 or newer. If SQLite rejects a STRICT schema, rerun without `--strict`.
+- `--strict` requests SQLite STRICT tables. On SQLite older than 3.37, the tool logs a warning and automatically
+  creates non-STRICT tables instead; rerun with SQLite 3.37 or newer to get STRICT schemas.
 - MySQL views become SQLite views by default. Use `--mysql-views-as-tables` for the older materialized-table behavior.
 
 ## MySQL, MariaDB, and SQLite notes

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Or run the published Docker image:
 docker run --rm ghcr.io/techouse/mysql-to-sqlite3:latest --help
 ```
 
+## Agent skill
+
+This repo includes an optional agent skill at [`skills/mysql-to-sqlite3/`](skills/mysql-to-sqlite3/) for users who want
+Codex or another compatible agent to help prepare a safe `mysql2sqlite` transfer command. The skill is user-facing: it
+focuses on migration planning, CLI recipes, password-safe defaults, and MySQL/MariaDB caveats.
+
 ## Quick start
 
 Use `-p` / `--prompt-mysql-password` for interactive password entry. This avoids putting the password in shell history

--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ docker run --rm ghcr.io/techouse/mysql-to-sqlite3:latest --help
 
 ## Agent skill
 
-This repo includes an optional agent skill at [`skills/mysql-to-sqlite3/`](skills/mysql-to-sqlite3/) for users who want
-Codex or another compatible agent to help prepare a safe `mysql2sqlite` transfer command. The skill is user-facing: it
-focuses on migration planning, CLI recipes, password-safe defaults, and MySQL/MariaDB caveats.
+This repo includes an optional agent skill at
+[`skills/mysql-to-sqlite3/`](https://github.com/techouse/mysql-to-sqlite3/tree/master/skills/mysql-to-sqlite3) for users
+who want Codex or another compatible agent to help prepare a safe `mysql2sqlite` transfer command. The skill is
+user-facing: it focuses on migration planning, CLI recipes, password-safe defaults, and MySQL/MariaDB caveats.
 
 ## Quick start
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -228,7 +228,7 @@ Options at a glance
    * - ``-W``, ``--without-data``
      - Create schema only and skip table data.
    * - ``-M``, ``--strict``
-     - Create SQLite STRICT tables when the local SQLite version supports them.
+     - Request SQLite STRICT tables; older SQLite versions fall back to non-STRICT tables with a warning.
    * - ``--mysql-charset TEXT``
      - MySQL database and table character set. Defaults to ``utf8mb4``.
    * - ``--mysql-collation TEXT``
@@ -274,8 +274,9 @@ Combinations and caveats
 - ``--mysql-ssl-cert`` and ``--mysql-ssl-key`` must be provided together.
 - ``--mysql-collation`` must be valid for the selected ``--mysql-charset``.
 - ``--limit-rows`` must be ``0`` or a positive integer. ``0`` means no limit.
-- ``--strict`` requires SQLite 3.37 or newer. If SQLite rejects a STRICT schema,
-  rerun without ``--strict``.
+- ``--strict`` requests SQLite STRICT tables. On SQLite older than 3.37, the
+  tool logs a warning and automatically creates non-STRICT tables instead; rerun
+  with SQLite 3.37 or newer to get STRICT schemas.
 - MySQL views become SQLite views by default. Use ``--mysql-views-as-tables``
   for the older materialized-table behavior.
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,105 +1,298 @@
 Usage
 -----
 
-Options
-^^^^^^^
+``mysql2sqlite`` transfers MySQL or MariaDB schema and data to a SQLite 3
+database file. It reads the source schema from MySQL/MariaDB, creates
+equivalent SQLite tables, indexes, views, and foreign keys where possible, then
+transfers table data into the SQLite file.
 
-The command line options for the ``mysql2sqlite`` tool are as follows:
+Prerequisites
+^^^^^^^^^^^^^
+
+- Python 3.9 or newer, unless you use the Docker image.
+- A reachable MySQL or MariaDB server.
+- A MySQL user that can read the source database and its metadata in
+  ``information_schema``.
+- A writable destination path for the SQLite database file.
+
+The project CI tests MySQL 5.5, 5.6, 5.7, 8.0, and 8.4, plus MariaDB 5.5,
+10.0, 10.6, 10.11, 11.4, and 11.8. Very old server versions are more likely to
+differ in type, default-value, authentication, or metadata behavior.
+
+Installation
+^^^^^^^^^^^^
+
+Install from PyPI:
 
 .. code-block:: bash
 
-   mysql2sqlite [OPTIONS]
+   pip install mysql-to-sqlite3
+   mysql2sqlite --help
 
-Required Options
-""""""""""""""""
+On macOS, you can also install with Homebrew:
 
-- ``-f, --sqlite-file PATH``: SQLite3 database file. This option is required.
-- ``-d, --mysql-database TEXT``: MySQL database name. This option is required.
-- ``-u, --mysql-user TEXT``: MySQL user. This option is required.
-
-Password Options
-""""""""""""""""
-
-- ``-p, --prompt-mysql-password``: Prompt for MySQL password.
-- ``--mysql-password TEXT``: MySQL password.
-
-Table Options
-"""""""""""""
-
-- ``-t, --mysql-tables TUPLE``: Transfer only these specific tables (space separated table names). Implies --without-foreign-keys which inhibits the transfer of foreign keys. Can not be used together with --exclude-mysql-tables.
-- ``-e, --exclude-mysql-tables TUPLE``: Transfer all tables except these specific tables (space separated table names). Implies --without-foreign-keys which inhibits the transfer of foreign keys. Can not be used together with --mysql-tables.
-
-Transfer Options
-""""""""""""""""
-
-- ``-T, --mysql-views-as-tables``: Materialize MySQL VIEWs as SQLite tables (legacy behavior).
-- ``-L, --limit-rows INTEGER``: Transfer only a limited number of rows from each table.
-- ``-C, --collation [BINARY|NOCASE|RTRIM]``: Create datatypes of TEXT affinity using a specified collation sequence. The default is BINARY.
-- ``-K, --prefix-indices``: Prefix indices with their corresponding tables. This ensures that their names remain unique across the SQLite database.
-- ``-X, --without-foreign-keys``: Do not transfer foreign keys.
-- ``-Z, --without-tables``: Do not transfer tables, data only.
-- ``-W, --without-data``: Do not transfer table data, DDL only.
-- ``-M, --strict``: Create SQLite STRICT tables when supported.
-
-Connection Options
-""""""""""""""""""
-
-- ``-h, --mysql-host TEXT``: MySQL host. Defaults to localhost.
-- ``-P, --mysql-port INTEGER``: MySQL port. Defaults to 3306.
-- ``--mysql-charset TEXT``: MySQL database and table character set. The default is utf8mb4.
-- ``--mysql-collation TEXT``: MySQL database and table collation.
-- ``--mysql-ssl-ca PATH``: Path to SSL CA certificate file.
-- ``--mysql-ssl-cert PATH``: Path to SSL certificate file. Must be provided together with ``--mysql-ssl-key``.
-- ``--mysql-ssl-key PATH``: Path to SSL key file. Must be provided together with ``--mysql-ssl-cert``.
-- ``-S, --skip-ssl``: Disable MySQL connection encryption. Cannot be used together with ``--mysql-ssl-*`` options.
-
-Other Options
-"""""""""""""
-
-- ``-c, --chunk INTEGER``: Chunk reading/writing SQL records.
-- ``-l, --log-file PATH``: Log file.
-- ``--json-as-text``: Transfer JSON columns as TEXT.
-- ``-V, --vacuum``: Use the VACUUM command to rebuild the SQLite database file, repacking it into a minimal amount of disk space.
-- ``--use-buffered-cursors``: Use MySQLCursorBuffered for reading the MySQL database. This can be useful in situations where multiple queries, with small result sets, need to be combined or computed with each other.
-- ``-q, --quiet``: Quiet. Display only errors.
-- ``--debug``: Debug mode. Will throw exceptions.
-- ``--version``: Show the version and exit.
-- ``--help``: Show this message and exit.
-
-Docker
-^^^^^^
-
-If you don’t want to install the tool on your system, you can use the
-Docker image instead.
-
-.. code:: bash
-
-   docker run -it \
-       --workdir $(pwd) \
-       --volume $(pwd):$(pwd) \
-       --rm ghcr.io/techouse/mysql-to-sqlite3:latest \
-       --sqlite-file baz.db \
-       --mysql-user foo \
-       --mysql-password bar \
-       --mysql-database baz \
-       --mysql-host host.docker.internal
-
-This will mount your host current working directory (pwd) inside the
-Docker container as the current working directory. Any files Docker
-would write to the current working directory are written to the host
-directory where you did docker run. Note that you have to also use a
-`special
-hostname <https://docs.docker.com/desktop/networking/#use-cases-and-workarounds-for-all-platforms>`__
-``host.docker.internal`` to access your host machine from inside the
-Docker container.
-
-Homebrew
-^^^^^^^^
-
-If you’re on macOS, you can install the tool using
-`Homebrew <https://brew.sh/>`__.
-
-.. code:: bash
+.. code-block:: bash
 
    brew install mysql-to-sqlite3
    mysql2sqlite --help
+
+Or run the published Docker image:
+
+.. code-block:: bash
+
+   docker run --rm ghcr.io/techouse/mysql-to-sqlite3:latest --help
+
+Quick start
+^^^^^^^^^^^
+
+Use ``-p`` / ``--prompt-mysql-password`` for interactive password entry. This
+avoids putting the password in shell history or process listings.
+
+.. code-block:: bash
+
+   mysql2sqlite \
+       --sqlite-file ./app.sqlite3 \
+       --mysql-database app_db \
+       --mysql-user app_user \
+       --prompt-mysql-password \
+       --mysql-host 127.0.0.1 \
+       --mysql-port 3306
+
+Short options are equivalent:
+
+.. code-block:: bash
+
+   mysql2sqlite -f ./app.sqlite3 -d app_db -u app_user -p -h 127.0.0.1 -P 3306
+
+For automation, ``--mysql-password`` is available, but prefer a secret manager
+or environment-expanded value rather than typing the password directly into your
+shell history.
+
+Common recipes
+^^^^^^^^^^^^^^
+
+Run with Docker
+"""""""""""""""
+
+Use ``host.docker.internal`` when the MySQL server is running on the host
+machine and the Docker container needs to reach it.
+
+.. code-block:: bash
+
+   docker run -it \
+       --rm \
+       --workdir "$PWD" \
+       --volume "$PWD:$PWD" \
+       ghcr.io/techouse/mysql-to-sqlite3:latest \
+       -f ./app.sqlite3 \
+       -d app_db \
+       -u app_user \
+       -p \
+       -h host.docker.internal
+
+Files written inside the mounted working directory are written back to the host
+directory.
+
+Transfer schema only
+""""""""""""""""""""
+
+Create the SQLite tables, indexes, views, and foreign keys without transferring
+table rows.
+
+.. code-block:: bash
+
+   mysql2sqlite -f ./schema.sqlite3 -d app_db -u app_user -p --without-data
+
+Transfer data into an existing SQLite schema
+""""""""""""""""""""""""""""""""""""""""""""
+
+``--without-tables`` skips DDL creation and only inserts data. The SQLite tables
+must already exist.
+
+.. code-block:: bash
+
+   mysql2sqlite -f ./app.sqlite3 -d app_db -u app_user -p --without-tables
+
+A common two-step flow is:
+
+.. code-block:: bash
+
+   mysql2sqlite -f ./app.sqlite3 -d app_db -u app_user -p --without-data
+   mysql2sqlite -f ./app.sqlite3 -d app_db -u app_user -p --without-tables
+
+Transfer only some tables
+"""""""""""""""""""""""""
+
+Table names are space-separated and are consumed until the next CLI option.
+
+.. code-block:: bash
+
+   mysql2sqlite -f ./subset.sqlite3 -d app_db -u app_user -p --mysql-tables users orders invoices
+
+Transfer everything except selected tables:
+
+.. code-block:: bash
+
+   mysql2sqlite -f ./subset.sqlite3 -d app_db -u app_user -p --exclude-mysql-tables audit_log temp_imports
+
+Selecting or excluding tables disables foreign key transfer because the
+referenced tables may not be present.
+
+Sample rows from every table
+""""""""""""""""""""""""""""
+
+Transfer at most 100 rows from each table:
+
+.. code-block:: bash
+
+   mysql2sqlite -f ./sample.sqlite3 -d app_db -u app_user -p --limit-rows 100
+
+Tune large transfers
+""""""""""""""""""""
+
+The CLI fetches and writes rows in batches by default. Use ``--chunk`` to tune
+the batch size. ``--vacuum`` repacks the SQLite file after the transfer
+finishes.
+
+.. code-block:: bash
+
+   mysql2sqlite -f ./app.sqlite3 -d app_db -u app_user -p --chunk 50000 --vacuum
+
+Use SSL certificates
+""""""""""""""""""""
+
+Verify the server certificate with a CA file:
+
+.. code-block:: bash
+
+   mysql2sqlite -f ./app.sqlite3 -d app_db -u app_user -p --mysql-ssl-ca /path/to/ca.pem
+
+Use a client certificate and key:
+
+.. code-block:: bash
+
+   mysql2sqlite \
+       -f ./app.sqlite3 \
+       -d app_db \
+       -u app_user \
+       -p \
+       --mysql-ssl-ca /path/to/ca.pem \
+       --mysql-ssl-cert /path/to/client-cert.pem \
+       --mysql-ssl-key /path/to/client-key.pem
+
+Use ``--skip-ssl`` only when you explicitly need to disable MySQL connection
+encryption.
+
+Options at a glance
+^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+
+   * - Option
+     - Purpose
+   * - ``-f``, ``--sqlite-file PATH``
+     - Destination SQLite database file. Required.
+   * - ``-d``, ``--mysql-database TEXT``
+     - Source MySQL/MariaDB database name. Required.
+   * - ``-u``, ``--mysql-user TEXT``
+     - MySQL/MariaDB user. Required.
+   * - ``-p``, ``--prompt-mysql-password``
+     - Prompt for the MySQL password. Preferred for interactive use.
+   * - ``--mysql-password TEXT``
+     - Provide the MySQL password directly. Useful for automation, but handle carefully.
+   * - ``-h``, ``--mysql-host TEXT``
+     - MySQL host. Defaults to ``localhost``.
+   * - ``-P``, ``--mysql-port INTEGER``
+     - MySQL port. Defaults to ``3306``.
+   * - ``-t``, ``--mysql-tables TUPLE``
+     - Transfer only the listed tables. Implies no foreign key transfer.
+   * - ``-e``, ``--exclude-mysql-tables TUPLE``
+     - Transfer every table except the listed tables. Implies no foreign key transfer.
+   * - ``-T``, ``--mysql-views-as-tables``
+     - Materialize MySQL views as SQLite tables instead of creating SQLite views.
+   * - ``-L``, ``--limit-rows INTEGER``
+     - Transfer at most this many rows from each table. ``0`` means no limit.
+   * - ``-C``, ``--collation [BINARY|NOCASE|RTRIM]``
+     - Add a SQLite collation to text-affinity columns. Defaults to ``BINARY``.
+   * - ``-K``, ``--prefix-indices``
+     - Prefix SQLite index names with their table names.
+   * - ``-X``, ``--without-foreign-keys``
+     - Do not create foreign keys in the SQLite schema.
+   * - ``-Z``, ``--without-tables``
+     - Skip table/view creation and transfer data only.
+   * - ``-W``, ``--without-data``
+     - Create schema only and skip table data.
+   * - ``-M``, ``--strict``
+     - Create SQLite STRICT tables when the local SQLite version supports them.
+   * - ``--mysql-charset TEXT``
+     - MySQL connection character set. Defaults to ``utf8mb4``.
+   * - ``--mysql-collation TEXT``
+     - MySQL connection collation. Must belong to the selected charset.
+   * - ``--mysql-ssl-ca PATH``
+     - Path to an SSL CA certificate file.
+   * - ``--mysql-ssl-cert PATH``
+     - Path to an SSL client certificate file. Must be paired with ``--mysql-ssl-key``.
+   * - ``--mysql-ssl-key PATH``
+     - Path to an SSL client key file. Must be paired with ``--mysql-ssl-cert``.
+   * - ``-S``, ``--skip-ssl``
+     - Disable MySQL connection encryption. Cannot be used with SSL certificate options.
+   * - ``-c``, ``--chunk INTEGER``
+     - Read and write SQL records in batches. Defaults to ``200000``.
+   * - ``-l``, ``--log-file PATH``
+     - Write logs to a file.
+   * - ``--json-as-text``
+     - Force MySQL/MariaDB JSON columns to SQLite ``TEXT``.
+   * - ``-V``, ``--vacuum``
+     - Run SQLite ``VACUUM`` after transfer.
+   * - ``--use-buffered-cursors``
+     - Use buffered MySQL cursors.
+   * - ``-q``, ``--quiet``
+     - Show only errors after the initial command banner.
+   * - ``--debug``
+     - Re-raise exceptions for debugging instead of printing friendly errors.
+   * - ``--version``
+     - Show environment and dependency versions.
+   * - ``--help``
+     - Show CLI help.
+
+Combinations and caveats
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+- ``--mysql-tables`` and ``--exclude-mysql-tables`` are mutually exclusive.
+- ``--mysql-tables`` or ``--exclude-mysql-tables`` automatically disables
+  foreign key transfer.
+- ``--without-tables`` and ``--without-data`` cannot be used together because
+  there would be nothing to do.
+- ``--without-tables`` requires the destination SQLite schema to already exist.
+- ``--skip-ssl`` cannot be combined with ``--mysql-ssl-ca``,
+  ``--mysql-ssl-cert``, or ``--mysql-ssl-key``.
+- ``--mysql-ssl-cert`` and ``--mysql-ssl-key`` must be provided together.
+- ``--mysql-collation`` must be valid for the selected ``--mysql-charset``.
+- ``--limit-rows`` must be ``0`` or a positive integer. ``0`` means no limit.
+- ``--strict`` requires SQLite 3.37 or newer. If SQLite rejects a STRICT schema,
+  rerun without ``--strict``.
+- MySQL views become SQLite views by default. Use ``--mysql-views-as-tables``
+  for the older materialized-table behavior.
+
+MySQL, MariaDB, and SQLite notes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- MySQL and MariaDB are similar but not identical. Default expressions,
+  generated defaults, authentication plugins, JSON behavior, and metadata
+  returned from ``information_schema`` can differ by server family and version.
+- Older legacy servers may not support newer column types such as native
+  ``JSON``.
+- MySQL/MariaDB ``JSON`` columns map to SQLite ``JSON`` only when this tool
+  detects SQLite JSON1 support. Otherwise they map to ``TEXT``. Use
+  ``--json-as-text`` to force ``TEXT``.
+- ``ENUM``, ``SET``, unsupported spatial/network-style types, and unknown types
+  fall back to ``TEXT``.
+- MySQL ``TIMESTAMP`` columns are represented as SQLite ``DATETIME``.
+- Unsigned integer types are converted to their signed SQLite-compatible type
+  names.
+- Table names, column names, and index names are quoted for SQLite. Duplicate
+  SQLite index names are made unique, and ``--prefix-indices`` can make this
+  behavior explicit.
+- After transfer, verify schema details that are important to your application,
+  especially defaults, collations, JSON columns, views, and foreign keys.

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -75,7 +75,9 @@ Run with Docker
 """""""""""""""
 
 Use ``host.docker.internal`` when the MySQL server is running on the host
-machine and the Docker container needs to reach it.
+machine and the Docker container needs to reach it. On Linux Docker Engine, add
+``--add-host=host.docker.internal:host-gateway`` before the image name if
+``host.docker.internal`` is not resolvable.
 
 .. code-block:: bash
 
@@ -226,9 +228,9 @@ Options at a glance
    * - ``-M``, ``--strict``
      - Create SQLite STRICT tables when the local SQLite version supports them.
    * - ``--mysql-charset TEXT``
-     - MySQL connection character set. Defaults to ``utf8mb4``.
+     - MySQL database and table character set. Defaults to ``utf8mb4``.
    * - ``--mysql-collation TEXT``
-     - MySQL connection collation. Must belong to the selected charset.
+     - MySQL database and table collation. Must belong to the selected charset.
    * - ``--mysql-ssl-ca PATH``
      - Path to an SSL CA certificate file.
    * - ``--mysql-ssl-cert PATH``

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -15,9 +15,11 @@ Prerequisites
   ``information_schema``.
 - A writable destination path for the SQLite database file.
 
-The project CI tests MySQL 5.5, 5.6, 5.7, 8.0, and 8.4, plus MariaDB 5.5,
-10.0, 10.6, 10.11, 11.4, and 11.8. Very old server versions are more likely to
-differ in type, default-value, authentication, or metadata behavior.
+See the `GitHub Actions CI matrix
+<https://github.com/techouse/mysql-to-sqlite3/blob/master/.github/workflows/test.yml>`__
+for the current MySQL and MariaDB versions tested by the project. Very old
+server versions are more likely to differ in type, default-value,
+authentication, or metadata behavior.
 
 Installation
 ^^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,8 @@
 MySQL to SQLite3
 ================
 
-A simple Python tool to transfer data from MySQL to SQLite 3
+A Python CLI for transferring MySQL or MariaDB schema and data to a SQLite 3
+database file.
 
 |PyPI| |PyPI - Downloads| |Homebrew Formula Downloads| |PyPI - Python Version|
 |MySQL Support| |MariaDB Support| |GitHub license| |Contributor Covenant|
@@ -11,16 +12,36 @@ A simple Python tool to transfer data from MySQL to SQLite 3
 Installation
 ------------
 
-.. code:: bash
+.. code-block:: bash
 
    pip install mysql-to-sqlite3
 
 Basic Usage
 -----------
 
-.. code:: bash
+Use the password prompt for interactive use:
 
-   mysql2sqlite -f path/to/foo.sqlite -d foo_db -u foo_user -p
+.. code-block:: bash
+
+   mysql2sqlite -f ./app.sqlite3 -d app_db -u app_user -p -h 127.0.0.1 -P 3306
+
+Tested Databases
+----------------
+
+The CI matrix tests MySQL 5.5, 5.6, 5.7, 8.0, and 8.4, plus MariaDB 5.5,
+10.0, 10.6, 10.11, 11.4, and 11.8.
+
+Common Tasks
+------------
+
+- Use ``--without-data`` to create schema only.
+- Use ``--without-tables`` to transfer data into an existing SQLite schema.
+- Use ``--mysql-tables`` or ``--exclude-mysql-tables`` to transfer a table
+  subset; this disables foreign key transfer.
+- Use ``--mysql-ssl-ca``, ``--mysql-ssl-cert``, and ``--mysql-ssl-key`` for
+  certificate-based MySQL connections.
+
+See :doc:`README` for full recipes, option notes, and MySQL/MariaDB caveats.
 
 .. toctree::
    :maxdepth: 2
@@ -44,16 +65,16 @@ Indices and tables
    :target: https://formulae.brew.sh/formula/mysql-to-sqlite3
 .. |PyPI - Python Version| image:: https://img.shields.io/pypi/pyversions/mysql-to-sqlite3?logo=python
    :target: https://pypi.org/project/mysql-to-sqlite3/
-.. |MySQL Support| image:: https://img.shields.io/static/v1?logo=mysql&label=MySQL&message=5.5+%7C+5.6+%7C+5.7+%7C+8.0&color=2b5d80
-   :target: https://img.shields.io/static/v1?label=MySQL&message=5.6+%7C+5.7+%7C+8.0&color=2b5d80
-.. |MariaDB Support| image:: https://img.shields.io/static/v1?logo=mariadb&label=MariaDB&message=5.5+%7C+10.0+%7C+10.1+%7C+10.2+%7C+10.3+%7C+10.4+%7C+10.5+%7C+10.6%7C+10.11&color=C0765A
-   :target: https://img.shields.io/static/v1?label=MariaDB&message=10.0+%7C+10.1+%7C+10.2+%7C+10.3+%7C+10.4+%7C+10.5&color=C0765A
+.. |MySQL Support| image:: https://img.shields.io/static/v1?logo=mysql&label=MySQL&message=5.5%7C5.6%7C5.7%7C8.0%7C8.4&color=2b5d80
+   :target: https://github.com/techouse/mysql-to-sqlite3/actions/workflows/test.yml
+.. |MariaDB Support| image:: https://img.shields.io/static/v1?logo=mariadb&label=MariaDB&message=5.5%7C10.0%7C10.6%7C10.11%7C11.4%7C11.8&color=C0765A
+   :target: https://github.com/techouse/mysql-to-sqlite3/actions/workflows/test.yml
 .. |GitHub license| image:: https://img.shields.io/github/license/techouse/mysql-to-sqlite3
    :target: https://github.com/techouse/mysql-to-sqlite3/blob/master/LICENSE
 .. |Contributor Covenant| image:: https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?logo=contributorcovenant
    :target: CODE-OF-CONDUCT.md
 .. |PyPI - Format| image:: https://img.shields.io/pypi/format/mysql-to-sqlite3?logo=python
-   :target: https://pypi.org/project/sqlite3-to-mysql/
+   :target: https://pypi.org/project/mysql-to-sqlite3/
 .. |Code style: black| image:: https://img.shields.io/badge/code%20style-black-000000.svg?logo=python
    :target: https://github.com/ambv/black
 .. |Codacy Badge| image:: https://api.codacy.com/project/badge/Grade/64aae8e9599746d58d277852b35cc2bd
@@ -61,7 +82,7 @@ Indices and tables
 .. |Test Status| image:: https://github.com/techouse/mysql-to-sqlite3/actions/workflows/test.yml/badge.svg
    :target: https://github.com/techouse/mysql-to-sqlite3/actions/workflows/test.yml
 .. |CodeQL Status| image:: https://github.com/techouse/mysql-to-sqlite3/actions/workflows/github-code-scanning/codeql/badge.svg
-   :target: https://github.com/techouse/mysql-to-sqlite3/actions/workflows/codeql-analysis.yml
+   :target: https://github.com/techouse/mysql-to-sqlite3/actions/workflows/github-code-scanning/codeql
 .. |Publish PyPI Package Status| image:: https://github.com/techouse/mysql-to-sqlite3/actions/workflows/publish.yml/badge.svg
    :target: https://github.com/techouse/mysql-to-sqlite3/actions/workflows/publish.yml
 .. |codecov| image:: https://codecov.io/gh/techouse/mysql-to-sqlite3/branch/master/graph/badge.svg

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,8 +28,9 @@ Use the password prompt for interactive use:
 Tested Databases
 ----------------
 
-The CI matrix tests MySQL 5.5, 5.6, 5.7, 8.0, and 8.4, plus MariaDB 5.5,
-10.0, 10.6, 10.11, 11.4, and 11.8.
+See the `GitHub Actions CI matrix
+<https://github.com/techouse/mysql-to-sqlite3/blob/master/.github/workflows/test.yml>`__
+for the current MySQL and MariaDB versions tested by the project.
 
 Common Tasks
 ------------

--- a/skills/mysql-to-sqlite3/SKILL.md
+++ b/skills/mysql-to-sqlite3/SKILL.md
@@ -40,7 +40,9 @@ Use short flags when the user asks for a compact command:
 mysql2sqlite -f ./app.sqlite3 -d app_db -u app_user -p -h 127.0.0.1 -P 3306
 ```
 
-For Docker, mount the working directory and use `host.docker.internal` when MySQL or MariaDB runs on the host machine:
+For Docker, mount the working directory and use `host.docker.internal` when MySQL or MariaDB runs on the host machine.
+On Linux Docker Engine, include `--add-host=host.docker.internal:host-gateway` before the image name when the user is on
+Linux or says `host.docker.internal` does not resolve:
 
 ```bash
 docker run -it \
@@ -55,7 +57,7 @@ docker run -it \
     -h host.docker.internal
 ```
 
-If the CLI is not installed, give the install command that matches the user's platform:
+If the CLI is not installed, give the installation command that matches the user's platform:
 
 ```bash
 pip install mysql-to-sqlite3

--- a/skills/mysql-to-sqlite3/SKILL.md
+++ b/skills/mysql-to-sqlite3/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: mysql-to-sqlite3
+description: Use this skill whenever a user wants to transfer, migrate, convert, sample, troubleshoot, or generate commands for moving MySQL or MariaDB schema and data into SQLite using mysql2sqlite. This skill helps gather the required connection details, choose a local or Docker workflow, produce safe copy-pasteable commands, and explain mysql2sqlite caveats.
+---
+
+# mysql2sqlite Transfer Assistant
+
+Help users plan and run `mysql2sqlite` transfers from MySQL or MariaDB into a SQLite 3 database file. Focus on user migration outcomes, not on project development.
+
+## Start With Inputs
+
+Before giving a final command, collect any missing details that materially affect the command:
+
+- Destination SQLite file path for `-f` / `--sqlite-file`.
+- Source database name for `-d` / `--mysql-database`.
+- MySQL/MariaDB user for `-u` / `--mysql-user`.
+- Host and port when the server is not local; default to `localhost` and `3306` only when that matches the user's setup.
+- Runtime preference: installed CLI, PyPI install, Homebrew install, or Docker image.
+- Whether they need a full transfer, schema only, data into an existing schema, selected tables, excluded tables, row-limited sample, SSL, views as tables, STRICT tables, or JSON-as-text behavior.
+
+Do not ask users to paste database passwords. Prefer `-p` / `--prompt-mysql-password` for interactive commands. Use `--mysql-password` only for automation examples, and tell users to provide it through their secret-management mechanism rather than hard-coding it.
+
+## Command Defaults
+
+Use this full-transfer command as the base local pattern:
+
+```bash
+mysql2sqlite \
+    --sqlite-file ./app.sqlite3 \
+    --mysql-database app_db \
+    --mysql-user app_user \
+    --prompt-mysql-password \
+    --mysql-host 127.0.0.1 \
+    --mysql-port 3306
+```
+
+Use short flags when the user asks for a compact command:
+
+```bash
+mysql2sqlite -f ./app.sqlite3 -d app_db -u app_user -p -h 127.0.0.1 -P 3306
+```
+
+For Docker, mount the working directory and use `host.docker.internal` when MySQL or MariaDB runs on the host machine:
+
+```bash
+docker run -it \
+    --rm \
+    --workdir "$PWD" \
+    --volume "$PWD:$PWD" \
+    ghcr.io/techouse/mysql-to-sqlite3:latest \
+    -f ./app.sqlite3 \
+    -d app_db \
+    -u app_user \
+    -p \
+    -h host.docker.internal
+```
+
+If the CLI is not installed, give the install command that matches the user's platform:
+
+```bash
+pip install mysql-to-sqlite3
+```
+
+```bash
+brew install mysql-to-sqlite3
+```
+
+## Recipes
+
+Use these options to adapt the base command:
+
+- Schema only: add `--without-data`.
+- Data only into an existing SQLite schema: add `--without-tables`; tell the user the target tables must already exist.
+- Selected tables: add `--mysql-tables table_a table_b`; note that foreign keys are not transferred for table subsets.
+- Excluded tables: add `--exclude-mysql-tables audit_log temp_imports`; note that foreign keys are not transferred for table subsets.
+- Row-limited sample: add `--limit-rows 100`; `0` means no row limit.
+- SSL CA verification: add `--mysql-ssl-ca /path/to/ca.pem`.
+- Client certificate authentication: add `--mysql-ssl-cert /path/to/client-cert.pem --mysql-ssl-key /path/to/client-key.pem`, usually with `--mysql-ssl-ca`.
+- Large transfers: tune `--chunk 50000` when needed and add `--vacuum` if the user wants SQLite repacked after transfer.
+- MySQL views: by default, MySQL views become SQLite views; add `--mysql-views-as-tables` only when the user wants materialized tables.
+- JSON: add `--json-as-text` when the user wants MySQL/MariaDB JSON columns forced to SQLite `TEXT`.
+- SQLite STRICT tables: add `--strict` only when the user's local SQLite is 3.37 or newer.
+
+## Combinations To Check
+
+Warn before producing commands with these invalid or risky combinations:
+
+- `--mysql-tables` and `--exclude-mysql-tables` are mutually exclusive.
+- `--mysql-tables` or `--exclude-mysql-tables` disables foreign key transfer.
+- `--without-tables` and `--without-data` cannot be used together because there would be nothing to do.
+- `--without-tables` alone requires existing target SQLite tables.
+- `--skip-ssl` cannot be combined with `--mysql-ssl-ca`, `--mysql-ssl-cert`, or `--mysql-ssl-key`.
+- `--mysql-ssl-cert` and `--mysql-ssl-key` must be provided together.
+- `--mysql-collation` must belong to the selected `--mysql-charset`.
+- `--limit-rows` must be `0` or a positive integer; negative values are invalid.
+- `--strict` only creates SQLite STRICT tables on SQLite 3.37 or newer.
+
+## MySQL, MariaDB, And SQLite Notes
+
+Use these notes when users ask about compatibility or results:
+
+- The project CI tests MySQL 5.5, 5.6, 5.7, 8.0, and 8.4, plus MariaDB 5.5, 10.0, 10.6, 10.11, 11.4, and 11.8.
+- MySQL and MariaDB have drifted; defaults, JSON behavior, authentication plugins, and `information_schema` metadata can differ by version.
+- Older servers may not support newer native types such as `JSON`.
+- MySQL/MariaDB `JSON` maps to SQLite `JSON` only when SQLite JSON1 is available; otherwise it maps to `TEXT`. `--json-as-text` forces `TEXT`.
+- `ENUM`, `SET`, unsupported spatial/network-style types, and unknown types fall back to `TEXT`.
+- MySQL `TIMESTAMP` columns are represented as SQLite `DATETIME`.
+- Users should verify important defaults, collations, JSON columns, views, and foreign keys after transfer.
+
+## Response Shape
+
+For command-generation requests, answer with:
+
+1. A short statement of assumptions, especially host, port, runtime, destination file, and whether `-p` will prompt for the password.
+2. One copy-pasteable command.
+3. A brief caveats section only for options used in that command.
+4. A verification suggestion such as opening the SQLite file with `sqlite3 ./app.sqlite3 ".tables"` or running application-specific checks.
+
+Keep commands concrete. Use placeholders only when the user has not provided a required value, and label them clearly, such as `app_db`, `app_user`, or `/path/to/ca.pem`.

--- a/skills/mysql-to-sqlite3/SKILL.md
+++ b/skills/mysql-to-sqlite3/SKILL.md
@@ -101,7 +101,7 @@ Warn before producing commands with these invalid or risky combinations:
 
 Use these notes when users ask about compatibility or results:
 
-- The project CI tests MySQL 5.5, 5.6, 5.7, 8.0, and 8.4, plus MariaDB 5.5, 10.0, 10.6, 10.11, 11.4, and 11.8.
+- Use the GitHub Actions CI matrix as the source of truth for currently tested MySQL and MariaDB versions.
 - MySQL and MariaDB have drifted; defaults, JSON behavior, authentication plugins, and `information_schema` metadata can differ by version.
 - Older servers may not support newer native types such as `JSON`.
 - MySQL/MariaDB `JSON` maps to SQLite `JSON` only when SQLite JSON1 is available; otherwise it maps to `TEXT`. `--json-as-text` forces `TEXT`.

--- a/skills/mysql-to-sqlite3/SKILL.md
+++ b/skills/mysql-to-sqlite3/SKILL.md
@@ -81,7 +81,7 @@ Use these options to adapt the base command:
 - Large transfers: tune `--chunk 50000` when needed and add `--vacuum` if the user wants SQLite repacked after transfer.
 - MySQL views: by default, MySQL views become SQLite views; add `--mysql-views-as-tables` only when the user wants materialized tables.
 - JSON: add `--json-as-text` when the user wants MySQL/MariaDB JSON columns forced to SQLite `TEXT`.
-- SQLite STRICT tables: add `--strict` only when the user's local SQLite is 3.37 or newer.
+- SQLite STRICT tables: add `--strict` to request STRICT tables; older SQLite versions log a warning and create non-STRICT tables.
 
 ## Combinations To Check
 
@@ -95,7 +95,7 @@ Warn before producing commands with these invalid or risky combinations:
 - `--mysql-ssl-cert` and `--mysql-ssl-key` must be provided together.
 - `--mysql-collation` must belong to the selected `--mysql-charset`.
 - `--limit-rows` must be `0` or a positive integer; negative values are invalid.
-- `--strict` only creates SQLite STRICT tables on SQLite 3.37 or newer.
+- `--strict` requests SQLite STRICT tables; older SQLite versions log a warning and create non-STRICT tables.
 
 ## MySQL, MariaDB, And SQLite Notes
 


### PR DESCRIPTION
This pull request makes substantial improvements to documentation, project guidelines, and the user experience for the MySQL-to-SQLite3 transfer tool. The main focus is on enhancing clarity and completeness of the `README.md`, adding a new contributor guide, and updating internal documentation to reflect best practices and recent changes. These updates make it easier for both users and contributors to understand, install, and use the tool effectively.

**Documentation and User Experience Improvements:**

* Expanded and reorganized the `README.md` to provide a clearer project overview, prerequisites, installation steps (including Homebrew and Docker), agent skill usage, and detailed usage recipes. Added a comprehensive options table, clarified option combinations and caveats, and included notes on MySQL/MariaDB/SQLite differences.
* Updated badge links and fixed minor errors in the `README.md` for accuracy and consistency (e.g., correct PyPI project link, improved MySQL/MariaDB badge URLs).

**Contributor and Project Guidelines:**

* Added a new `AGENTS.md` file describing repository structure, development and testing commands, coding style, naming conventions, testing guidelines, commit/PR expectations, and database/security notes. This makes onboarding and contribution much easier.

**Internal Documentation Updates:**

* Updated `.github/copilot-instructions.md` to clarify which documentation files should be updated when CLI options change, including the new `docs/README.rst`. Also improved wording and examples for chunked transfers and documentation updates. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L19-R29) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L77-R79) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L98-R100)

These changes collectively improve the accessibility, maintainability, and professionalism of the project for both users and contributors.