### PR TITLE
:technologist: add MySQL 9.7.0 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -467,8 +467,20 @@ jobs:
             experimental: true
             py: "3.9"
 
+          - toxenv: "python3.9"
+            db: "mysql:9.7"
+            legacy_db: 0
+            experimental: true
+            py: "3.9"
+
           - toxenv: "python3.10"
             db: "mysql:8.4"
+            legacy_db: 0
+            experimental: true
+            py: "3.10"
+
+          - toxenv: "python3.10"
+            db: "mysql:9.7"
             legacy_db: 0
             experimental: true
             py: "3.10"
@@ -479,8 +491,20 @@ jobs:
             experimental: true
             py: "3.11"
 
+          - toxenv: "python3.11"
+            db: "mysql:9.7"
+            legacy_db: 0
+            experimental: true
+            py: "3.11"
+
           - toxenv: "python3.12"
             db: "mysql:8.4"
+            legacy_db: 0
+            experimental: true
+            py: "3.12"
+
+          - toxenv: "python3.12"
+            db: "mysql:9.7"
             legacy_db: 0
             experimental: true
             py: "3.12"
@@ -491,14 +515,32 @@ jobs:
             experimental: true
             py: "3.13"
 
+          - toxenv: "python3.13"
+            db: "mysql:9.7"
+            legacy_db: 0
+            experimental: true
+            py: "3.13"
+
           - toxenv: "python3.14"
             db: "mysql:8.4"
             legacy_db: 0
             experimental: true
             py: "3.14"
 
+          - toxenv: "python3.14"
+            db: "mysql:9.7"
+            legacy_db: 0
+            experimental: true
+            py: "3.14"
+
           - toxenv: "python3.14t"
             db: "mysql:8.4"
+            legacy_db: 0
+            experimental: true
+            py: "3.14t"
+
+          - toxenv: "python3.14t"
+            db: "mysql:9.7"
             legacy_db: 0
             experimental: true
             py: "3.14t"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -592,7 +592,7 @@ jobs:
           set -e
           
           case "$DB" in
-            'mysql:8.0'|'mysql:8.4')
+            'mysql:8.0'|'mysql:8.4'|'mysql:9.7')
               mysql -h127.0.0.1 -uroot -e "SET GLOBAL local_infile=on"
               docker cp mysqld:/var/lib/mysql/public_key.pem "${HOME}"
               docker cp mysqld:/var/lib/mysql/ca.pem "${HOME}"
@@ -615,7 +615,7 @@ jobs:
               nopass_caching_sha2 IDENTIFIED WITH "caching_sha2_password"
               PASSWORD EXPIRE NEVER;
               GRANT RELOAD ON *.* TO user_caching_sha2;'
-          elif [ "$DB" == 'mysql:8.4' ]; then
+          elif [[ "$DB" == 'mysql:8.4' || "$DB" == 'mysql:9.7' ]]; then
             WITH_PLUGIN='with caching_sha2_password'
             USER_CREATION_COMMANDS='
               CREATE USER

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,13 @@ interactions related to the project.
 
 Ensuring backward compatibility is an imperative requirement.
 
-Currently, the tool supports Python versions 3.9, 3.10, 3.11, 3.12, 3.13, and 3.14.
+Currently, the tool supports Python versions 3.9, 3.10, 3.11, 3.12, 3.13, and 3.14, including 3.14t (free-threaded).
 
 ## MySQL version support
 
-This tool is intended to fully support MySQL versions 5.5, 5.6, 5.7, and 8.0, including major forks like MariaDB.
-We should prioritize and be dedicated to maintaining compatibility with these versions for a smooth user experience.
+This tool is intended to fully support MySQL versions 5.5, 5.6, 5.7, 8.0, 8.4, and 9.7, including major forks like
+MariaDB. We should prioritize and be dedicated to maintaining compatibility with these versions for a smooth user
+experience.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/mysql-to-sqlite3?logo=pypi&label=PyPI%20downloads)](https://pypistats.org/packages/mysql-to-sqlite3)
 [![Homebrew Formula Downloads](https://img.shields.io/homebrew/installs/dm/mysql-to-sqlite3?logo=homebrew&label=Homebrew%20downloads)](https://formulae.brew.sh/formula/mysql-to-sqlite3)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/mysql-to-sqlite3?logo=python)](https://pypi.org/project/mysql-to-sqlite3/)
-[![MySQL Support](https://img.shields.io/static/v1?logo=mysql&label=MySQL&message=5.5%7C5.6%7C5.7%7C8.0%7C8.4&color=2b5d80)](https://github.com/techouse/mysql-to-sqlite3/actions/workflows/test.yml)
+[![MySQL Support](https://img.shields.io/static/v1?logo=mysql&label=MySQL&message=5.5%7C5.6%7C5.7%7C8.0%7C8.4%7C9.7&color=2b5d80)](https://github.com/techouse/mysql-to-sqlite3/actions/workflows/test.yml)
 [![MariaDB Support](https://img.shields.io/static/v1?logo=mariadb&label=MariaDB&message=5.5%7C10.0%7C10.6%7C10.11%7C11.4%7C11.8&color=C0765A)](https://github.com/techouse/mysql-to-sqlite3/actions/workflows/test.yml)
 [![GitHub license](https://img.shields.io/github/license/techouse/mysql-to-sqlite3)](https://github.com/techouse/mysql-to-sqlite3/blob/master/LICENSE)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?logo=contributorcovenant)](CODE-OF-CONDUCT.md)
@@ -192,40 +192,40 @@ Use `--skip-ssl` only when you explicitly need to disable MySQL connection encry
 
 ## Options at a glance
 
-| Option | Purpose |
-| --- | --- |
-| `-f`, `--sqlite-file PATH` | Destination SQLite database file. Required. |
-| `-d`, `--mysql-database TEXT` | Source MySQL/MariaDB database name. Required. |
-| `-u`, `--mysql-user TEXT` | MySQL/MariaDB user. Required. |
-| `-p`, `--prompt-mysql-password` | Prompt for the MySQL password. Preferred for interactive use. |
-| `--mysql-password TEXT` | Provide the MySQL password directly. Useful for automation, but handle carefully. |
-| `-h`, `--mysql-host TEXT` | MySQL host. Defaults to `localhost`. |
-| `-P`, `--mysql-port INTEGER` | MySQL port. Defaults to `3306`. |
-| `-t`, `--mysql-tables TUPLE` | Transfer only the listed tables. Implies no foreign key transfer. |
-| `-e`, `--exclude-mysql-tables TUPLE` | Transfer every table except the listed tables. Implies no foreign key transfer. |
-| `-T`, `--mysql-views-as-tables` | Materialize MySQL views as SQLite tables instead of creating SQLite views. |
-| `-L`, `--limit-rows INTEGER` | Transfer at most this many rows from each table. `0` means no limit. |
-| `-C`, `--collation [BINARY\|NOCASE\|RTRIM]` | Add a SQLite collation to text-affinity columns. Defaults to `BINARY`. |
-| `-K`, `--prefix-indices` | Prefix SQLite index names with their table names. |
-| `-X`, `--without-foreign-keys` | Do not create foreign keys in the SQLite schema. |
-| `-Z`, `--without-tables` | Skip table/view creation and transfer data only. |
-| `-W`, `--without-data` | Create schema only and skip table data. |
-| `-M`, `--strict` | Request SQLite STRICT tables; older SQLite versions fall back to non-STRICT tables with a warning. |
-| `--mysql-charset TEXT` | MySQL database and table character set. Defaults to `utf8mb4`. |
-| `--mysql-collation TEXT` | MySQL database and table collation. Must belong to the selected charset. |
-| `--mysql-ssl-ca PATH` | Path to an SSL CA certificate file. |
-| `--mysql-ssl-cert PATH` | Path to an SSL client certificate file. Must be paired with `--mysql-ssl-key`. |
-| `--mysql-ssl-key PATH` | Path to an SSL client key file. Must be paired with `--mysql-ssl-cert`. |
-| `-S`, `--skip-ssl` | Disable MySQL connection encryption. Cannot be used with SSL certificate options. |
-| `-c`, `--chunk INTEGER` | Read and write SQL records in batches. Defaults to `200000`. |
-| `-l`, `--log-file PATH` | Write logs to a file. |
-| `--json-as-text` | Force MySQL/MariaDB JSON columns to SQLite `TEXT`. |
-| `-V`, `--vacuum` | Run SQLite `VACUUM` after transfer. |
-| `--use-buffered-cursors` | Use buffered MySQL cursors. |
-| `-q`, `--quiet` | Show only errors after the initial command banner. |
-| `--debug` | Re-raise exceptions for debugging instead of printing friendly errors. |
-| `--version` | Show environment and dependency versions. |
-| `--help` | Show CLI help. |
+| Option                                      | Purpose                                                                                            |
+|---------------------------------------------|----------------------------------------------------------------------------------------------------|
+| `-f`, `--sqlite-file PATH`                  | Destination SQLite database file. Required.                                                        |
+| `-d`, `--mysql-database TEXT`               | Source MySQL/MariaDB database name. Required.                                                      |
+| `-u`, `--mysql-user TEXT`                   | MySQL/MariaDB user. Required.                                                                      |
+| `-p`, `--prompt-mysql-password`             | Prompt for the MySQL password. Preferred for interactive use.                                      |
+| `--mysql-password TEXT`                     | Provide the MySQL password directly. Useful for automation, but handle carefully.                  |
+| `-h`, `--mysql-host TEXT`                   | MySQL host. Defaults to `localhost`.                                                               |
+| `-P`, `--mysql-port INTEGER`                | MySQL port. Defaults to `3306`.                                                                    |
+| `-t`, `--mysql-tables TUPLE`                | Transfer only the listed tables. Implies no foreign key transfer.                                  |
+| `-e`, `--exclude-mysql-tables TUPLE`        | Transfer every table except the listed tables. Implies no foreign key transfer.                    |
+| `-T`, `--mysql-views-as-tables`             | Materialize MySQL views as SQLite tables instead of creating SQLite views.                         |
+| `-L`, `--limit-rows INTEGER`                | Transfer at most this many rows from each table. `0` means no limit.                               |
+| `-C`, `--collation [BINARY\|NOCASE\|RTRIM]` | Add a SQLite collation to text-affinity columns. Defaults to `BINARY`.                             |
+| `-K`, `--prefix-indices`                    | Prefix SQLite index names with their table names.                                                  |
+| `-X`, `--without-foreign-keys`              | Do not create foreign keys in the SQLite schema.                                                   |
+| `-Z`, `--without-tables`                    | Skip table/view creation and transfer data only.                                                   |
+| `-W`, `--without-data`                      | Create schema only and skip table data.                                                            |
+| `-M`, `--strict`                            | Request SQLite STRICT tables; older SQLite versions fall back to non-STRICT tables with a warning. |
+| `--mysql-charset TEXT`                      | MySQL database and table character set. Defaults to `utf8mb4`.                                     |
+| `--mysql-collation TEXT`                    | MySQL database and table collation. Must belong to the selected charset.                           |
+| `--mysql-ssl-ca PATH`                       | Path to an SSL CA certificate file.                                                                |
+| `--mysql-ssl-cert PATH`                     | Path to an SSL client certificate file. Must be paired with `--mysql-ssl-key`.                     |
+| `--mysql-ssl-key PATH`                      | Path to an SSL client key file. Must be paired with `--mysql-ssl-cert`.                            |
+| `-S`, `--skip-ssl`                          | Disable MySQL connection encryption. Cannot be used with SSL certificate options.                  |
+| `-c`, `--chunk INTEGER`                     | Read and write SQL records in batches. Defaults to `200000`.                                       |
+| `-l`, `--log-file PATH`                     | Write logs to a file.                                                                              |
+| `--json-as-text`                            | Force MySQL/MariaDB JSON columns to SQLite `TEXT`.                                                 |
+| `-V`, `--vacuum`                            | Run SQLite `VACUUM` after transfer.                                                                |
+| `--use-buffered-cursors`                    | Use buffered MySQL cursors.                                                                        |
+| `-q`, `--quiet`                             | Show only errors after the initial command banner.                                                 |
+| `--debug`                                   | Re-raise exceptions for debugging instead of printing friendly errors.                             |
+| `--version`                                 | Show environment and dependency versions.                                                          |
+| `--help`                                    | Show CLI help.                                                                                     |
 
 ## Combinations and caveats
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,7 +66,7 @@ Indices and tables
    :target: https://formulae.brew.sh/formula/mysql-to-sqlite3
 .. |PyPI - Python Version| image:: https://img.shields.io/pypi/pyversions/mysql-to-sqlite3?logo=python
    :target: https://pypi.org/project/mysql-to-sqlite3/
-.. |MySQL Support| image:: https://img.shields.io/static/v1?logo=mysql&label=MySQL&message=5.5%7C5.6%7C5.7%7C8.0%7C8.4&color=2b5d80
+.. |MySQL Support| image:: https://img.shields.io/static/v1?logo=mysql&label=MySQL&message=5.5%7C5.6%7C5.7%7C8.0%7C8.4%7C9.7&color=2b5d80
    :target: https://github.com/techouse/mysql-to-sqlite3/actions/workflows/test.yml
 .. |MariaDB Support| image:: https://img.shields.io/static/v1?logo=mariadb&label=MariaDB&message=5.5%7C10.0%7C10.6%7C10.11%7C11.4%7C11.8&color=C0765A
    :target: https://github.com/techouse/mysql-to-sqlite3/actions/workflows/test.yml


### PR DESCRIPTION
This pull request updates MySQL version support across the documentation and CI workflows to include MySQL 9.7, and clarifies Python and MySQL compatibility. It also fixes a minor formatting issue in the options table.

**Compatibility and documentation updates:**

* Updated the supported MySQL versions in the `README.md` badge and `CONTRIBUTING.md` to include MySQL 9.7, ensuring users are aware of the latest compatibility. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L16-R22)
* Clarified Python version support in `CONTRIBUTING.md` to explicitly mention Python 3.14t (free-threaded).

**Continuous Integration (CI) improvements:**

* Added new test matrix entries in `.github/workflows/test.yml` to run the test suite against MySQL 9.7 for all supported Python versions, including 3.14 and 3.14t, ensuring ongoing compatibility.

**Minor fixes:**

* Fixed markdown formatting in the options table in `README.md` for improved readability.